### PR TITLE
DASH job number end-to-end

### DIFF
--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -5,7 +5,7 @@ class JobProposalsController < ApplicationController
   EDITABLE_PARAMS = %i[
     customer_title customer_first_name customer_last_name customer_email
     customer_house_number customer_street customer_city customer_state customer_zip
-    internal_reference loss_notes loss_reason
+    internal_reference dash_job_number loss_notes loss_reason
     owner_id job_type_id scenario_id proposal_value
   ].freeze
 

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -15,6 +15,12 @@ class JobProposal < ApplicationRecord
        { in_campaign: "in_campaign", won: "won", lost: "lost" },
        prefix: true
 
+  # When the proposal's tenant requires a DASH-style job reference (per
+  # PRD-02 v1.5 §5 / PRD-10 v1.3.1 §7.5), require it before approving the
+  # proposal — but allow drafting and approving states to persist without
+  # one so the operator can fill it in on the edit form.
+  validate :dash_job_number_required_when_approved
+
   # Operator hasn't done their part yet on this proposal — it sits in
   # one of: drafting (not finished), approving (campaign drafted but
   # awaiting operator approval), or approved+in-campaign with an
@@ -100,4 +106,12 @@ class JobProposal < ApplicationRecord
     joined.presence
   end
 
+  private
+
+  def dash_job_number_required_when_approved
+    return unless tenant&.job_reference_required
+    return if dash_job_number.present?
+    return if status_drafting? || status_approving?
+    errors.add(:dash_job_number, "is required before this job can be approved")
+  end
 end

--- a/app/services/mail_generator.rb
+++ b/app/services/mail_generator.rb
@@ -134,6 +134,17 @@ class MailGenerator
     end
   end
 
+  # When the proposal carries a DASH job number, prefix it on the email
+  # subject so Jeff's DASH inbox can thread on it (CC-06 v1.2 §1; PRD-02
+  # v1.5 §5). Idempotent — if the subject already starts with the same
+  # prefix (e.g., the operator hand-edited a draft body), don't double up.
+  def self.prefix_dash_job_number(subject, dash_job_number)
+    return subject if dash_job_number.blank?
+    prefix = "[DASH-#{dash_job_number}]"
+    return subject if subject.to_s.start_with?(prefix)
+    "#{prefix} #{subject}".strip
+  end
+
   # Appends a standard sign-off block to every email body so individual
   # campaign templates don't have to repeat (and drift on) the
   # "name / phone / email / org" pattern. Built from already-resolved
@@ -172,6 +183,7 @@ class MailGenerator
       raise UnresolvedMergeFieldError, "Unresolved merge fields: #{unresolved.join(", ")}"
     end
 
+    subject = self.class.prefix_dash_job_number(subject, @job_proposal.dash_job_number)
     body = self.class.append_signature(body, values)
     Output.new(subject:, body:)
   end

--- a/app/views/job_proposals/edit.html.erb
+++ b/app/views/job_proposals/edit.html.erb
@@ -108,6 +108,15 @@
           <%= f.label :internal_reference, "Internal reference", class: "form-label" %>
           <%= f.text_field :internal_reference, class: "form-control", disabled: @campaign_in_flight %>
         </div>
+        <% if @job_proposal.tenant&.job_reference_required %>
+          <div class="col-md-6">
+            <%= f.label :dash_job_number, "DASH job number", class: "form-label" %>
+            <%= f.text_field :dash_job_number, class: "form-control", disabled: @campaign_in_flight,
+                  required: !@job_proposal.status_drafting?,
+                  placeholder: "e.g. 12345" %>
+            <div class="form-text">Required before this job can be approved. Prefixed onto every campaign email subject so the thread stays threaded in DASH.</div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/db/migrate/20260509000505_add_dash_job_number_support.rb
+++ b/db/migrate/20260509000505_add_dash_job_number_support.rb
@@ -1,0 +1,7 @@
+class AddDashJobNumberSupport < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenants, :job_reference_required, :boolean, null: false, default: false
+    add_column :job_proposals, :dash_job_number, :string
+    add_index :job_proposals, :dash_job_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,27 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "expires_at"
-    t.bigint "location_id"
     t.string "provider", default: "google", null: false
     t.text "refresh_token"
     t.text "scopes"
     t.datetime "updated_at", null: false
-    t.index ["location_id"], name: "index_application_mailboxes_on_location_id", unique: true, where: "(location_id IS NOT NULL)"
-  end
-
-  create_table "audit_logs", force: :cascade do |t|
-    t.string "action", null: false
-    t.bigint "actor_user_id"
-    t.datetime "created_at", null: false
-    t.jsonb "payload", default: {}, null: false
-    t.bigint "target_id", null: false
-    t.string "target_type", null: false
-    t.bigint "tenant_id", null: false
-    t.index ["action"], name: "index_audit_logs_on_action"
-    t.index ["actor_user_id"], name: "index_audit_logs_on_actor_user_id"
-    t.index ["created_at"], name: "index_audit_logs_on_created_at"
-    t.index ["target_type", "target_id"], name: "index_audit_logs_on_target_type_and_target_id"
-    t.index ["tenant_id"], name: "index_audit_logs_on_tenant_id"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -351,10 +334,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   end
 
   create_table "tenants", force: :cascade do |t|
-    t.string "company_name"
     t.datetime "created_at", null: false
     t.boolean "job_reference_required", default: false, null: false
-    t.string "logo_url"
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
@@ -402,9 +383,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "application_mailboxes", "locations"
-  add_foreign_key "audit_logs", "tenants"
-  add_foreign_key "audit_logs", "users", column: "actor_user_id"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/test/models/job_proposal_test.rb
+++ b/test/models/job_proposal_test.rb
@@ -227,4 +227,38 @@ class JobProposalTest < ActiveSupport::TestCase
     refute jp.valid?
     assert_includes jp.errors[:location], "must exist"
   end
+
+  # --- DASH job number gating --------------------------------------------
+
+  test "dash_job_number is not required when the tenant flag is false" do
+    tenants(:one).update!(job_reference_required: false)
+    @jp.update!(status: :approved, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is not required while the proposal is drafting (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :drafting, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is not required while approving (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :approving, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is required to transition to approved (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.dash_job_number = nil
+    @jp.status = :approved
+    refute @jp.valid?
+    assert_includes @jp.errors[:dash_job_number], "is required before this job can be approved"
+  end
+
+  test "dash_job_number satisfies the gate when present (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :approved, dash_job_number: "98765")
+    assert_equal "98765", @jp.reload.dash_job_number
+  end
 end

--- a/test/services/mail_generator_test.rb
+++ b/test/services/mail_generator_test.rb
@@ -245,6 +245,35 @@ class MailGeneratorTest < ActiveSupport::TestCase
 
   # --- signature ---
 
+  # --- DASH subject prefix -----------------------------------------------
+
+  test "subject is prefixed with [DASH-NNN] when the proposal has a dash_job_number" do
+    @job.update!(dash_job_number: "12345")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "Following up on {property_address_short}", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "[DASH-12345] Following up on 1247 Oak Ridge Drive", out.subject
+  end
+
+  test "subject is unchanged when dash_job_number is blank" do
+    @job.update!(dash_job_number: nil)
+    out = MailGenerator.render(
+      campaign_step: step(subject: "Hello", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "Hello", out.subject
+  end
+
+  test "DASH prefix is idempotent — subject already prefixed isn't doubled" do
+    @job.update!(dash_job_number: "12345")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "[DASH-12345] Already prefixed", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "[DASH-12345] Already prefixed", out.subject
+  end
+
   test "render appends the signature with originator + company info" do
     out = MailGenerator.render(
       campaign_step: step(subject: "X", body: "Body text."),


### PR DESCRIPTION
## Summary

PR 3 of 7 in the v0.1 - Happy Path stack. Closes #151. **Wedge gate** — without this Jeff can't track jobs in DASH and the pilot fails.

- `tenants.job_reference_required` — boolean flag, default `false`. Jeff's tenant gets this set to `true` once SMAI staff seeds his account.
- `job_proposals.dash_job_number` — string, indexed. Captured on the edit form when the tenant flag is on. Required to transition past `:approving`.
- `MailGenerator` prefixes the subject with `[DASH-NNN]` when present, idempotently.

## Stack position

Base: `pr/prd01-schema` (#156). Next PR (#160 Account fields + audit logging) branches from this. PRs #158 (template version on Job Detail) and #159 (mailbox per location) were dropped from the stack — not pursuing in v0.1.