### PR TITLE
Surface resolved template version on Job Detail

### DIFF
--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -140,6 +140,20 @@
       <dl class="row mb-0 px-3 pt-3">
         <dt class="col-sm-3">Campaign</dt>
         <dd class="col-sm-9"><%= link_to campaign_instance.campaign.name, job_proposal_campaign_instance_path(@job_proposal, campaign_instance) %></dd>
+
+        <dt class="col-sm-3">Template version</dt>
+        <dd class="col-sm-9">
+          <% template_version = campaign_instance.campaign.template_version_id %>
+          <% if template_version.present? %>
+            <code><%= template_version %></code>
+          <% else %>
+            <span class="text-muted">—</span>
+            <div class="form-text">No template version recorded yet — campaigns get a version once SPEC-11 v2.0 template_versions land.</div>
+          <% end %>
+          <% if campaign_instance.campaign.approved_at %>
+            <div class="text-muted small">approved <%= campaign_instance.campaign.approved_at.to_date.to_fs(:long) %></div>
+          <% end %>
+        </dd>
       </dl>
 
       <% step_instances = campaign_instance.step_instances

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -219,6 +219,32 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Job Proposal ##{jp.id}", response.body
   end
 
+  test "show page surfaces the resolved campaign and template version under the Campaign card" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    campaign = campaigns(:approved_campaign)
+    campaign.update!(template_version_id: "v1.2-water-mitigation-001")
+    CampaignInstance.create!(host: jp, campaign: campaign, status: :active)
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_match "Template version", response.body
+    assert_match "v1.2-water-mitigation-001", response.body
+  end
+
+  test "show page renders an em-dash placeholder when template_version_id is blank" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    campaign = campaigns(:approved_campaign)
+    campaign.update!(template_version_id: nil)
+    CampaignInstance.create!(host: jp, campaign: campaign, status: :active)
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_match "Template version", response.body
+    assert_match "No template version recorded yet", response.body
+  end
+
   test "show step table includes a Thread column linking to the Gmail conversation when present" do
     sign_in @user
     jp = job_proposals(:in_users_org)


### PR DESCRIPTION
## Summary

PR 4 of 9. Closes #153. Surfaces the resolved campaign template version on the Job Detail Campaign card per CC-06 v1.2 §E.

Reads `campaigns.template_version_id` (added in PR #156). When the campaign carries a version it renders as a `<code>` tag with the campaign's approval date underneath. When blank, an em-dash placeholder with a note that values land once SPEC-11 v2.0 template_versions ships.

## Test plan

- [x] `rails test` — 663 runs, 0 failures.
- [ ] Smoke: open a Job Detail page for an in-flight proposal — confirm the Template version row renders alongside the existing Campaign row.

## Stack position

Base: `pr/dash-end-to-end` (#157). Next PR (#99 mailbox per location) branches from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)