### PR TITLE
Mailbox per location (PRD-09 §5)

### DIFF
--- a/app/controllers/campaign_instances_controller.rb
+++ b/app/controllers/campaign_instances_controller.rb
@@ -12,7 +12,7 @@ class CampaignInstancesController < ApplicationController
   before_action :load_proposal_and_instance
 
   def show
-    @from_address = ApplicationMailbox.current&.email
+    @from_address = ApplicationMailbox.for_proposal(@job_proposal)&.email
     @to_address   = @job_proposal.customer_email.presence
 
     step_instances = @campaign_instance.step_instances

--- a/app/controllers/campaign_step_instances_controller.rb
+++ b/app/controllers/campaign_step_instances_controller.rb
@@ -47,7 +47,7 @@ class CampaignStepInstancesController < ApplicationController
       end
     end
 
-    @from_address = ApplicationMailbox.current&.email
+    @from_address = ApplicationMailbox.for_proposal(@job_proposal)&.email
     @to_address   = @job_proposal.customer_email.presence
   end
 

--- a/app/jobs/campaign_sweep_job.rb
+++ b/app/jobs/campaign_sweep_job.rb
@@ -46,9 +46,9 @@ class CampaignSweepJob < ApplicationJob
   end
 
   def perform
-    mailbox = ApplicationMailbox.current
+    has_any_mailbox = ApplicationMailbox.connected?
 
-    if mailbox
+    if has_any_mailbox
       # Real-send path: still gate non-prod behind TEST_TO_EMAIL so we
       # don't accidentally email customers from a dev/staging box.
       unless self.class.production_environment? || self.class.test_to_email_override
@@ -64,7 +64,11 @@ class CampaignSweepJob < ApplicationJob
       return
     end
 
-    due_step_instance_ids(Time.current).each { |id| process(id, mailbox) }
+    # Per PRD-09 §5, the per-location mailbox sends for that location's
+    # proposals; the legacy no-location mailbox is the fallback. Resolve
+    # per step instance so a tenant with mixed location coverage can
+    # still send from the right address.
+    due_step_instance_ids(Time.current).each { |id| process(id) }
   end
 
   private
@@ -85,10 +89,12 @@ class CampaignSweepJob < ApplicationJob
       .pluck("campaign_step_instances.id")
   end
 
-  def process(step_instance_id, mailbox)
+  def process(step_instance_id)
     return unless claim(step_instance_id)
 
     step_instance = CampaignStepInstance.find(step_instance_id)
+    host = step_instance.campaign_instance.host
+    mailbox = host.is_a?(JobProposal) ? ApplicationMailbox.for_proposal(host) : ApplicationMailbox.current
     deliver(step_instance, mailbox)
   end
 

--- a/app/jobs/gmail_reply_poll_job.rb
+++ b/app/jobs/gmail_reply_poll_job.rb
@@ -41,15 +41,20 @@ class GmailReplyPollJob < ApplicationJob
   POLLING_CUTOFF = 6.months
 
   def perform
-    mailbox = ApplicationMailbox.current
-    if mailbox.nil?
+    unless ApplicationMailbox.connected?
       Rails.logger.warn "[GmailReplyPollJob] no application mailbox connected; skipping poll"
       return
     end
 
-    sender = GmailSender.new(mailbox)
+    # Resolve a sender per step instance using its proposal's location
+    # so per-location mailboxes (PRD-09 §5) poll their own threads.
     pollable_step_instance_ids(Time.current).each do |id|
-      process(id, mailbox, sender)
+      step_instance = CampaignStepInstance.find(id)
+      host = step_instance.campaign_instance.host
+      mailbox = host.is_a?(JobProposal) ? ApplicationMailbox.for_proposal(host) : ApplicationMailbox.current
+      next if mailbox.nil?
+      sender = GmailSender.new(mailbox)
+      process(id, mailbox, sender, prefetched_step_instance: step_instance)
     end
   end
 
@@ -79,8 +84,8 @@ class GmailReplyPollJob < ApplicationJob
       .pluck("campaign_step_instances.id")
   end
 
-  def process(step_instance_id, mailbox, sender)
-    step_instance = CampaignStepInstance.find_by(id: step_instance_id)
+  def process(step_instance_id, mailbox, sender, prefetched_step_instance: nil)
+    step_instance = prefetched_step_instance || CampaignStepInstance.find_by(id: step_instance_id)
     return unless step_instance
 
     thread = sender.fetch_thread(step_instance.gmail_thread_id)

--- a/app/models/application_mailbox.rb
+++ b/app/models/application_mailbox.rb
@@ -1,14 +1,36 @@
-# Singleton: the one OAuth-connected mailbox the application uses to send
-# transactional email (invitations, Devise password resets, etc.). Distinct
+# OAuth-connected mailboxes the application uses to send transactional
+# email (invitations, Devise password resets, campaign sends). Distinct
 # from per-user EmailDelegation, which is used for on-behalf-of operator
 # sends from the user's own Gmail.
+#
+# Per PRD-09 §5, every location can have one dedicated operational
+# mailbox. The legacy "no location" mailbox stays around as a singleton
+# fallback for callers that aren't location-aware (e.g. Devise's
+# password-reset flow), and as the migration path for accounts that
+# haven't yet split per-location.
 class ApplicationMailbox < ApplicationRecord
+  belongs_to :location, optional: true
+
   validates :provider, :email, :access_token, presence: true
 
-  validate :only_one_record
+  validate :only_one_legacy_singleton
 
+  # The legacy no-location mailbox. Used by callers that don't have a
+  # location context (Devise transactional email, invitation send).
   def self.current
-    first
+    where(location_id: nil).first
+  end
+
+  # Resolve the right mailbox for a given location. Prefers the
+  # location-specific mailbox; falls back to the legacy singleton if
+  # the location hasn't had one provisioned yet.
+  def self.for_location(location)
+    return current if location.nil?
+    where(location_id: location.id).first || current
+  end
+
+  def self.for_proposal(job_proposal)
+    for_location(job_proposal&.location)
   end
 
   def self.connected?
@@ -21,9 +43,10 @@ class ApplicationMailbox < ApplicationRecord
 
   private
 
-  def only_one_record
-    if self.class.where.not(id: id).exists?
-      errors.add(:base, "An application mailbox is already configured. Disconnect it first.")
+  def only_one_legacy_singleton
+    return unless location_id.nil?
+    if self.class.where(location_id: nil).where.not(id: id).exists?
+      errors.add(:base, "A no-location application mailbox is already configured. Disconnect it first.")
     end
   end
 end

--- a/db/migrate/20260509000841_add_location_to_application_mailboxes.rb
+++ b/db/migrate/20260509000841_add_location_to_application_mailboxes.rb
@@ -1,0 +1,11 @@
+class AddLocationToApplicationMailboxes < ActiveRecord::Migration[8.1]
+  def change
+    # `add_reference` would create a non-unique index — we want a partial
+    # unique one instead, so disable the auto-index and add ours explicitly.
+    add_reference :application_mailboxes, :location, foreign_key: true, null: true, index: false
+    # At most one mailbox per location. The legacy "no location" singleton
+    # is allowed (location_id IS NULL); we don't add an index that uniques
+    # NULLs because Postgres treats them as distinct, which is what we want.
+    add_index :application_mailboxes, :location_id, unique: true, where: "location_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_000841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,10 +47,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "expires_at"
+    t.bigint "location_id"
     t.string "provider", default: "google", null: false
     t.text "refresh_token"
     t.text "scopes"
     t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_application_mailboxes_on_location_id", unique: true, where: "(location_id IS NOT NULL)"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -383,6 +385,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "application_mailboxes", "locations"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/test/models/application_mailbox_test.rb
+++ b/test/models/application_mailbox_test.rb
@@ -21,11 +21,46 @@ class ApplicationMailboxTest < ActiveSupport::TestCase
     refute ApplicationMailbox.new(valid_attrs(access_token: nil)).valid?
   end
 
-  test "only one mailbox can exist at a time" do
+  test "only one no-location mailbox can exist at a time" do
     ApplicationMailbox.create!(valid_attrs)
     second = ApplicationMailbox.new(valid_attrs(email: "another@app.example.com"))
     refute second.valid?
     assert_match(/already configured/i, second.errors[:base].join)
+  end
+
+  test "per-location mailboxes coexist alongside the no-location singleton" do
+    ApplicationMailbox.create!(valid_attrs(email: "global@app.example.com"))
+    loc_a = locations(:ne_dallas)
+    loc_b = tenants(:two).locations.create!(
+      display_name: "Globex West", address_line_1: "1 W", city: "X",
+      state: "CA", postal_code: "90001", phone_number: "(213) 555-0101"
+    )
+    ApplicationMailbox.create!(valid_attrs(email: "ne-dallas@app.example.com", location: loc_a))
+    ApplicationMailbox.create!(valid_attrs(email: "globex-west@app.example.com", location: loc_b))
+    assert_equal 3, ApplicationMailbox.count
+  end
+
+  test "for_location returns the per-location mailbox when present" do
+    loc = locations(:ne_dallas)
+    location_specific = ApplicationMailbox.create!(valid_attrs(email: "ne-dallas@app.example.com", location: loc))
+    ApplicationMailbox.create!(valid_attrs(email: "global@app.example.com"))
+    assert_equal location_specific, ApplicationMailbox.for_location(loc)
+  end
+
+  test "for_location falls back to the no-location singleton when no per-location mailbox exists" do
+    loc = locations(:ne_dallas)
+    legacy = ApplicationMailbox.create!(valid_attrs(email: "global@app.example.com"))
+    assert_equal legacy, ApplicationMailbox.for_location(loc)
+  end
+
+  test "for_location returns nil when nothing is configured" do
+    assert_nil ApplicationMailbox.for_location(locations(:ne_dallas))
+  end
+
+  test "for_proposal resolves via the proposal's location" do
+    jp = job_proposals(:in_users_org)
+    location_specific = ApplicationMailbox.create!(valid_attrs(email: "loc@app.example.com", location: jp.location))
+    assert_equal location_specific, ApplicationMailbox.for_proposal(jp)
   end
 
   test "expired? is false when expires_at is in the future" do


### PR DESCRIPTION
## Summary

PR 5 of 9. Closes #99. Per PRD-09 §5, every Location can now have one operational mailbox.

- `application_mailboxes.location_id` (nullable FK), partial unique index so each Location has at most one mailbox.
- `ApplicationMailbox.for_location(location)` / `.for_proposal(jp)` resolve the right mailbox; fall back to the legacy no-location singleton.
- `CampaignSweepJob` and `GmailReplyPollJob` resolve per step instance using the host proposal's location.
- Campaign Instance + Step Instance show pages display the correct from-address.

## Out of scope here

OAuth UI to connect a per-location mailbox. The existing `/admin/application_mailbox` page still drives the singleton fallback. The per-location connect flow lands once PR6 (admin/tenants overhaul + audit logging) provides the right home for it.

## Test plan

- [x] `rails test` — 668 runs, 0 failures.
- [ ] Smoke (post-merge of PR6): connect a per-location mailbox, send a campaign, verify the From-address matches.

## Stack position

Base: `pr/template-version-on-detail` (#158). Next PR (#106 Account CRUD + audit_logs) branches from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)