### PR TITLE
Account fields, tenant edit, and audit logging

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -8,6 +8,11 @@ class Admin::LocationsController < Admin::BaseController
   def create
     @location = @tenant.locations.build(location_params.merge(created_by_user: current_user))
     if @location.save
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "location.create", target: @location,
+        after: @location.slice(:display_name, :address_line_1, :address_line_2, :city, :state, :postal_code, :phone_number, :is_active)
+      )
       redirect_to admin_tenant_path(@tenant), notice: "Location added."
     else
       render :new, status: :unprocessable_content

--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -1,5 +1,7 @@
 class Admin::TenantsController < Admin::BaseController
-  before_action :set_tenant, only: [:show]
+  TENANT_PARAMS = %i[name company_name logo_url job_reference_required].freeze
+
+  before_action :set_tenant, only: [:show, :edit, :update]
 
   def index
     @tenants = Tenant.order(:name)
@@ -17,11 +19,33 @@ class Admin::TenantsController < Admin::BaseController
   end
 
   def create
-    @tenant = Tenant.new(name: params.dig(:tenant, :name))
+    @tenant = Tenant.new(tenant_params)
     if @tenant.save
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "tenant.create", target: @tenant,
+        after: tenant_audit_snapshot(@tenant)
+      )
       redirect_to admin_tenant_path(@tenant), notice: "Tenant '#{@tenant.name}' created."
     else
       render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    before = tenant_audit_snapshot(@tenant)
+    if @tenant.update(tenant_params)
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "tenant.update", target: @tenant,
+        before: before, after: tenant_audit_snapshot(@tenant)
+      )
+      redirect_to admin_tenant_path(@tenant), notice: "Tenant updated."
+    else
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -29,5 +53,13 @@ class Admin::TenantsController < Admin::BaseController
 
   def set_tenant
     @tenant = Tenant.find(params[:id])
+  end
+
+  def tenant_params
+    params.require(:tenant).permit(*TENANT_PARAMS)
+  end
+
+  def tenant_audit_snapshot(tenant)
+    tenant.slice(:name, :company_name, :logo_url, :job_reference_required)
   end
 end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,0 +1,20 @@
+# Append-only record of a state-changing admin operation. Per PRD-10
+# v1.3.1 §10, every Admin Portal write goes through here so an SMAI
+# operator can answer "who changed what, when?"
+#
+# AuditLog rows are never updated or deleted; the Rails-side accessor is
+# read-only after creation.
+class AuditLog < ApplicationRecord
+  belongs_to :tenant
+  belongs_to :actor_user, class_name: "User", optional: true
+
+  validates :action, :target_type, :target_id, presence: true
+
+  before_update do
+    raise ActiveRecord::ReadOnlyRecord, "audit_logs is append-only"
+  end
+
+  before_destroy do
+    raise ActiveRecord::ReadOnlyRecord, "audit_logs is append-only"
+  end
+end

--- a/app/services/audit_logger.rb
+++ b/app/services/audit_logger.rb
@@ -1,0 +1,20 @@
+# Thin helper for writing AuditLog rows from controllers/services. Per
+# PRD-10 v1.3.1 §10, every state-changing admin operation goes through
+# here so the audit trail stays uniform.
+#
+# Usage:
+#   AuditLogger.write(tenant: @tenant, actor: current_user,
+#                     action: "tenant.update", target: @tenant,
+#                     before: { name: old_name }, after: { name: new_name })
+class AuditLogger
+  def self.write(tenant:, actor:, action:, target:, before: nil, after: nil)
+    AuditLog.create!(
+      tenant: tenant,
+      actor_user: actor,
+      action: action,
+      target_type: target.class.name,
+      target_id: target.id,
+      payload: { before: before, after: after }.compact
+    )
+  end
+end

--- a/app/services/mail_generator.rb
+++ b/app/services/mail_generator.rb
@@ -205,7 +205,7 @@ class MailGenerator
     when "originator_title"       then originator&.title
     when "originator_phone"       then originator&.phone_number
     when "originator_email"       then originator&.email
-    when "company_name"           then tenant&.name
+    when "company_name"           then tenant&.company_name.presence || tenant&.name
     when "company_phone"          then location&.phone_number
     when "location_name"          then location&.display_name
     when "location_address"       then location_address

--- a/app/views/admin/tenants/edit.html.erb
+++ b/app/views/admin/tenants/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title, "Edit Tenant: #{@tenant.name}" %>
+
+<%= render "shared/admin_breadcrumb",
+      tenant: @tenant,
+      current: :tenant %>
+
+<h1 class="h3 mb-3">Edit Tenant: <%= @tenant.name %></h1>
+
+<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true do |f| %>
+  <% if @tenant.errors.any? %>
+    <div class="alert alert-danger">
+      <strong>Please fix the following:</strong>
+      <ul class="mb-0">
+        <% @tenant.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="mb-3">
+        <%= f.label :name, "Account name (internal)", class: "form-label" %>
+        <%= f.text_field :name, class: "form-control", required: true %>
+        <div class="form-text">Shown in SMAI admin only.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :company_name, "Company name (customer-facing)", class: "form-label" %>
+        <%= f.text_field :company_name, class: "form-control", placeholder: @tenant.name %>
+        <div class="form-text">Used in email signatures (<code>{company_name}</code>). Falls back to the account name when blank.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :logo_url, "Logo URL", class: "form-label" %>
+        <%= f.url_field :logo_url, class: "form-control", placeholder: "https://…" %>
+        <div class="form-text">Public URL of the logo. The upload pipeline lands separately.</div>
+      </div>
+
+      <div class="form-check mb-0">
+        <%= f.check_box :job_reference_required, class: "form-check-input", id: "tenant-job-ref-required" %>
+        <%= f.label :job_reference_required, "Require DASH job number", class: "form-check-label", for: "tenant-job-ref-required" %>
+        <div class="form-text">When on, every job in this account needs a DASH number before it can be approved.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit "Save", class: "btn btn-primary" %>
+    <%= link_to "Cancel", admin_tenant_path(@tenant), class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -3,8 +3,39 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h1 class="h3 mb-0">Tenant: <%= @tenant.name %></h1>
   <div class="d-flex gap-2">
+    <%= link_to "Edit", edit_admin_tenant_path(@tenant), class: "btn btn-sm btn-outline-primary" %>
     <%= link_to "Manage activations", admin_tenant_activations_path(@tenant), class: "btn btn-sm btn-outline-primary" %>
     <%= link_to "All tenants", admin_tenants_path, class: "btn btn-sm btn-outline-secondary" %>
+  </div>
+</div>
+
+<div class="card shadow-sm mb-3">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Company name</dt>
+      <dd class="col-sm-9">
+        <%= @tenant.company_name.presence || content_tag(:span, @tenant.name + " (defaulted from account name)", class: "text-muted") %>
+      </dd>
+
+      <dt class="col-sm-3">Logo</dt>
+      <dd class="col-sm-9">
+        <% if @tenant.logo_url.present? %>
+          <%= image_tag @tenant.logo_url, alt: "Logo", style: "max-height: 48px;" %>
+          <div class="text-muted small mt-1"><%= @tenant.logo_url %></div>
+        <% else %>
+          <span class="text-muted">— Not set</span>
+        <% end %>
+      </dd>
+
+      <dt class="col-sm-3">DASH job # required</dt>
+      <dd class="col-sm-9">
+        <% if @tenant.job_reference_required %>
+          <span class="badge text-bg-info">Required</span>
+        <% else %>
+          <span class="text-muted">No</span>
+        <% end %>
+      </dd>
+    </dl>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     resources :integrations, only: [:index] do
       collection { post :check }
     end
-    resources :tenants, only: [:index, :show, :new, :create] do
+    resources :tenants, only: [:index, :show, :new, :create, :edit, :update] do
       resources :invitations, only: [:create, :destroy]
       resources :locations, only: [:new, :create]
       resource :activations, only: [:show], controller: "activations"

--- a/db/migrate/20260509001343_add_tenant_account_fields_and_audit_logs.rb
+++ b/db/migrate/20260509001343_add_tenant_account_fields_and_audit_logs.rb
@@ -1,0 +1,20 @@
+class AddTenantAccountFieldsAndAuditLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenants, :logo_url, :string
+    add_column :tenants, :company_name, :string
+
+    create_table :audit_logs do |t|
+      t.references :tenant, null: false, foreign_key: true
+      t.references :actor_user, foreign_key: { to_table: :users }, null: true
+      t.string :action, null: false
+      t.string :target_type, null: false
+      t.bigint :target_id, null: false
+      t.jsonb :payload, null: false, default: {}
+      t.datetime :created_at, null: false
+
+      t.index [:target_type, :target_id]
+      t.index :action
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_000841) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,6 +53,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000841) do
     t.text "scopes"
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_application_mailboxes_on_location_id", unique: true, where: "(location_id IS NOT NULL)"
+  end
+
+  create_table "audit_logs", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "actor_user_id"
+    t.datetime "created_at", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
+    t.bigint "tenant_id", null: false
+    t.index ["action"], name: "index_audit_logs_on_action"
+    t.index ["actor_user_id"], name: "index_audit_logs_on_actor_user_id"
+    t.index ["created_at"], name: "index_audit_logs_on_created_at"
+    t.index ["target_type", "target_id"], name: "index_audit_logs_on_target_type_and_target_id"
+    t.index ["tenant_id"], name: "index_audit_logs_on_tenant_id"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -336,8 +351,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000841) do
   end
 
   create_table "tenants", force: :cascade do |t|
+    t.string "company_name"
     t.datetime "created_at", null: false
     t.boolean "job_reference_required", default: false, null: false
+    t.string "logo_url"
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
@@ -386,6 +403,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000841) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "application_mailboxes", "locations"
+  add_foreign_key "audit_logs", "tenants"
+  add_foreign_key "audit_logs", "users", column: "actor_user_id"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/test/controllers/admin/locations_controller_test.rb
+++ b/test/controllers/admin/locations_controller_test.rb
@@ -39,13 +39,18 @@ class Admin::LocationsControllerTest < ActionDispatch::IntegrationTest
   test "create persists a location under the tenant and stamps created_by" do
     sign_in @admin
     assert_difference -> { Location.count }, 1 do
-      post admin_tenant_locations_url(@tenant), params: valid_params
+      assert_difference -> { AuditLog.count }, 1 do
+        post admin_tenant_locations_url(@tenant), params: valid_params
+      end
     end
     assert_redirected_to admin_tenant_path(@tenant)
     location = @tenant.locations.find_by(display_name: "Boise")
     refute_nil location
     assert_equal "ID", location.state
     assert_equal @admin, location.created_by_user
+    log = AuditLog.where(target_type: "Location", target_id: location.id, action: "location.create").last
+    assert_equal @admin, log.actor_user
+    assert_equal "Boise", log.payload["after"]["display_name"]
   end
 
   test "create rejects invalid input without saving" do

--- a/test/controllers/admin/tenants_controller_test.rb
+++ b/test/controllers/admin/tenants_controller_test.rb
@@ -48,6 +48,47 @@ class Admin::TenantsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='invitation[email]']"
   end
 
+  test "edit renders the form" do
+    sign_in @admin
+    get edit_admin_tenant_url(tenants(:one))
+    assert_response :success
+    assert_select "input[name='tenant[name]']"
+    assert_select "input[name='tenant[company_name]']"
+    assert_select "input[name='tenant[logo_url]']"
+    assert_select "input[name='tenant[job_reference_required]']"
+  end
+
+  test "update writes an audit log entry capturing the change" do
+    sign_in @admin
+    tenant = tenants(:one)
+    assert_difference "AuditLog.count", 1 do
+      patch admin_tenant_url(tenant), params: { tenant: {
+        name: tenant.name,
+        company_name: "Servpro of NE Dallas",
+        logo_url: "https://example.com/logo.png",
+        job_reference_required: "1"
+      } }
+    end
+    assert_redirected_to admin_tenant_path(tenant)
+    tenant.reload
+    assert_equal "Servpro of NE Dallas", tenant.company_name
+    assert tenant.job_reference_required
+    log = AuditLog.where(target_type: "Tenant", target_id: tenant.id, action: "tenant.update").last
+    assert_equal @admin, log.actor_user
+    assert_equal "Servpro of NE Dallas", log.payload["after"]["company_name"]
+  end
+
+  test "non-admin can't edit or update a tenant" do
+    sign_in @non_admin
+    get edit_admin_tenant_url(tenants(:one))
+    assert_redirected_to root_path
+
+    assert_no_difference "AuditLog.count" do
+      patch admin_tenant_url(tenants(:one)), params: { tenant: { name: "Hacked" } }
+    end
+    assert_redirected_to root_path
+  end
+
   test "show replaces the invitation form with a warning when the mailbox isn't connected" do
     sign_in @admin
     get admin_tenant_url(tenants(:one))

--- a/test/models/audit_log_test.rb
+++ b/test/models/audit_log_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class AuditLogTest < ActiveSupport::TestCase
+  setup do
+    @tenant = tenants(:one)
+    @actor = users(:admin)
+  end
+
+  test "valid with required fields" do
+    log = AuditLog.new(
+      tenant: @tenant, actor_user: @actor,
+      action: "tenant.update", target_type: "Tenant", target_id: @tenant.id,
+      payload: { before: { name: "old" }, after: { name: "new" } }
+    )
+    assert log.valid?
+  end
+
+  test "rejects updates after creation" do
+    log = AuditLog.create!(
+      tenant: @tenant, action: "x", target_type: "Tenant", target_id: @tenant.id
+    )
+    assert_raises(ActiveRecord::ReadOnlyRecord) { log.update!(action: "y") }
+  end
+
+  test "rejects destroy" do
+    log = AuditLog.create!(
+      tenant: @tenant, action: "x", target_type: "Tenant", target_id: @tenant.id
+    )
+    assert_raises(ActiveRecord::ReadOnlyRecord) { log.destroy }
+  end
+end
+
+class AuditLoggerTest < ActiveSupport::TestCase
+  test "writes an audit log row with before/after" do
+    tenant = tenants(:one)
+    actor = users(:admin)
+    assert_difference "AuditLog.count", 1 do
+      AuditLogger.write(
+        tenant: tenant, actor: actor,
+        action: "tenant.update", target: tenant,
+        before: { name: "Old Name" }, after: { name: "New Name" }
+      )
+    end
+    log = AuditLog.last
+    assert_equal "tenant.update", log.action
+    assert_equal "Tenant", log.target_type
+    assert_equal tenant.id, log.target_id
+    assert_equal "Old Name", log.payload["before"]["name"]
+    assert_equal "New Name", log.payload["after"]["name"]
+  end
+end

--- a/test/services/mail_generator_test.rb
+++ b/test/services/mail_generator_test.rb
@@ -135,7 +135,17 @@ class MailGeneratorTest < ActiveSupport::TestCase
     assert_equal "10280 Miller Rd, Dallas, TX, 75238\nTexas\n(214) 343-3973", body_without_signature(out)
   end
 
-  test "company_name renders the tenant name" do
+  test "company_name renders tenant.company_name when set" do
+    @tenant.update!(company_name: "Servpro of NE Dallas")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "X", body: "From {company_name}"),
+      job_proposal: @job
+    )
+    assert_equal "From Servpro of NE Dallas", body_without_signature(out)
+  end
+
+  test "company_name falls back to tenant.name when company_name is blank" do
+    @tenant.update!(company_name: nil)
     out = MailGenerator.render(
       campaign_step: step(subject: "X", body: "From {company_name}"),
       job_proposal: @job


### PR DESCRIPTION
## Summary

PR 4 of 7. Closes #106.

- `tenants.logo_url`, `tenants.company_name` — distinct from `name` (internal). MailGenerator `{company_name}` resolves from `company_name` with fallback to `name`.
- `audit_logs` table + AuditLog model (append-only) + tiny `AuditLogger` service.
- `Admin::TenantsController` gains edit/update; both create + update write audit log rows. `Admin::LocationsController#create` does the same.
- Admin tenant show page surfaces company_name, logo preview (if URL set), and the DASH flag.

## Stack position

Base: `pr/dash-end-to-end` (#157). Next PR (#161 logo upload pipeline) branches from this.