### PR TITLE
Logo upload pipeline

### DIFF
--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -1,5 +1,5 @@
 class Admin::TenantsController < Admin::BaseController
-  TENANT_PARAMS = %i[name company_name logo_url job_reference_required].freeze
+  TENANT_PARAMS = %i[name company_name logo_url logo job_reference_required].freeze
 
   before_action :set_tenant, only: [:show, :edit, :update]
 
@@ -60,6 +60,9 @@ class Admin::TenantsController < Admin::BaseController
   end
 
   def tenant_audit_snapshot(tenant)
-    tenant.slice(:name, :company_name, :logo_url, :job_reference_required)
+    tenant.slice(:name, :company_name, :logo_url, :job_reference_required).merge(
+      logo_attached: tenant.logo.attached?,
+      logo_filename: tenant.logo.attached? ? tenant.logo.filename.to_s : nil
+    )
   end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -3,6 +3,13 @@ class Tenant < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :job_proposals, dependent: :destroy
   has_many :invitations, dependent: :destroy
+
+  # PRD-10 v1.3.1 §7 / SPEC-07 v1.4 §9 — every campaign email signature
+  # references the account's logo. Stored via Active Storage so SMAI staff
+  # (or eventually the operator UI) can upload via the admin portal. The
+  # string column `logo_url` is preserved as a manual override for tenants
+  # who'd rather link to a logo hosted elsewhere.
+  has_one_attached :logo
   has_many :tenant_job_types, dependent: :destroy
   has_many :tenant_scenarios, dependent: :destroy
 
@@ -21,4 +28,12 @@ class Tenant < ApplicationRecord
            source: :scenario
 
   validates :name, presence: true
+
+  # Resolves the right URL for templates / signatures: prefer the
+  # uploaded logo blob if attached, else the manual `logo_url` string,
+  # else nil. Callers handle the nil case.
+  def logo_image_url
+    return Rails.application.routes.url_helpers.rails_blob_url(logo, only_path: true) if logo.attached?
+    logo_url.presence
+  end
 end

--- a/app/views/admin/tenants/edit.html.erb
+++ b/app/views/admin/tenants/edit.html.erb
@@ -6,7 +6,7 @@
 
 <h1 class="h3 mb-3">Edit Tenant: <%= @tenant.name %></h1>
 
-<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true do |f| %>
+<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true, html: { multipart: true } do |f| %>
   <% if @tenant.errors.any? %>
     <div class="alert alert-danger">
       <strong>Please fix the following:</strong>
@@ -33,9 +33,21 @@
       </div>
 
       <div class="mb-3">
-        <%= f.label :logo_url, "Logo URL", class: "form-label" %>
+        <%= f.label :logo, "Logo (upload)", class: "form-label" %>
+        <% if @tenant.logo.attached? %>
+          <div class="mb-2">
+            <%= image_tag rails_blob_url(@tenant.logo, only_path: true), alt: "Current logo", style: "max-height: 64px;" %>
+            <div class="text-muted small mt-1"><%= @tenant.logo.filename %></div>
+          </div>
+        <% end %>
+        <%= f.file_field :logo, class: "form-control", accept: "image/*" %>
+        <div class="form-text">PNG, JPG, or SVG. Replaces any existing upload.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :logo_url, "Logo URL (manual override)", class: "form-label" %>
         <%= f.url_field :logo_url, class: "form-control", placeholder: "https://…" %>
-        <div class="form-text">Public URL of the logo. The upload pipeline lands separately.</div>
+        <div class="form-text">Used when no file is uploaded — link to a logo hosted elsewhere.</div>
       </div>
 
       <div class="form-check mb-0">

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -19,9 +19,16 @@
 
       <dt class="col-sm-3">Logo</dt>
       <dd class="col-sm-9">
-        <% if @tenant.logo_url.present? %>
-          <%= image_tag @tenant.logo_url, alt: "Logo", style: "max-height: 48px;" %>
-          <div class="text-muted small mt-1"><%= @tenant.logo_url %></div>
+        <% logo_src = @tenant.logo_image_url %>
+        <% if logo_src.present? %>
+          <%= image_tag logo_src, alt: "Logo", style: "max-height: 48px;" %>
+          <div class="text-muted small mt-1">
+            <% if @tenant.logo.attached? %>
+              Uploaded · <%= @tenant.logo.filename %>
+            <% else %>
+              <%= @tenant.logo_url %>
+            <% end %>
+          </div>
         <% else %>
           <span class="text-muted">— Not set</span>
         <% end %>

--- a/test/controllers/admin/tenants_controller_test.rb
+++ b/test/controllers/admin/tenants_controller_test.rb
@@ -78,6 +78,20 @@ class Admin::TenantsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Servpro of NE Dallas", log.payload["after"]["company_name"]
   end
 
+  test "update accepts a logo file upload via Active Storage" do
+    sign_in @admin
+    tenant = tenants(:one)
+    file = Rack::Test::UploadedFile.new(StringIO.new("fake image bytes"), "image/png", original_filename: "logo.png")
+
+    assert_difference "ActiveStorage::Attachment.count", 1 do
+      patch admin_tenant_url(tenant), params: { tenant: { name: tenant.name, logo: file } }
+    end
+    assert_redirected_to admin_tenant_path(tenant)
+    tenant.reload
+    assert tenant.logo.attached?
+    assert_equal "logo.png", tenant.logo.filename.to_s
+  end
+
   test "non-admin can't edit or update a tenant" do
     sign_in @non_admin
     get edit_admin_tenant_url(tenants(:one))

--- a/test/models/tenant_test.rb
+++ b/test/models/tenant_test.rb
@@ -30,4 +30,26 @@ class TenantTest < ActiveSupport::TestCase
     assert_equal [], tenant.activated_job_types.to_a
     assert_equal [], tenant.activated_scenarios.to_a
   end
+
+  # --- logo resolution ---------------------------------------------------
+
+  test "logo_image_url returns the manual logo_url when no file is attached" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: "https://example.com/logo.png")
+    assert_equal "https://example.com/logo.png", tenant.logo_image_url
+  end
+
+  test "logo_image_url returns nil when neither attachment nor manual URL is set" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: nil)
+    assert_nil tenant.logo_image_url
+  end
+
+  test "logo_image_url prefers an attached blob over the manual URL" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: "https://example.com/manual.png")
+    tenant.logo.attach(io: StringIO.new("fake image"), filename: "uploaded.png", content_type: "image/png")
+    assert_match(/rails\/active_storage\/blobs/, tenant.logo_image_url)
+    refute_match(/manual.png/, tenant.logo_image_url)
+  end
 end


### PR DESCRIPTION
## Summary

PR 5 of 7. Closes #107. Adds Active Storage support for tenant logos.

`Tenant.has_one_attached :logo` plus a `logo_image_url` resolver that prefers the uploaded blob, falls back to the manual `logo_url` column, and returns nil otherwise. Admin tenant edit form gets a `file_field` and the show page renders the resolved URL.

## Stack position

Base: `pr/account-location-crud` (#160). Next PR (#162 hero tiles MTD/YTD) branches from this.