### PR TITLE
Analytics: MTD/YTD on Conversion Rate hero tile (SPEC-05)

### DIFF
--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -42,6 +42,28 @@ class AnalyticsCalculator
 
     conversion_rate_pct = activated_count.positive? ? ((won_count.to_f / activated_count) * 100).round : nil
 
+    # MTD/YTD breakdown for the Conversion Rate hero tile per SPEC-05 v1.0.
+    # Activated count is bucketed by the campaign instance's created_at;
+    # won count is bucketed by the proposal's closed_at (set when the
+    # pipeline_stage flipped to won or lost).
+    now = Time.current
+    mtd_start = now.beginning_of_month
+    ytd_start = now.beginning_of_year
+
+    mtd_activated = @proposals
+      .joins(:campaign_instances)
+      .where("campaign_instances.created_at >= ?", mtd_start)
+      .distinct.count
+    ytd_activated = @proposals
+      .joins(:campaign_instances)
+      .where("campaign_instances.created_at >= ?", ytd_start)
+      .distinct.count
+    mtd_won = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", mtd_start).count
+    ytd_won = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", ytd_start).count
+
+    conversion_rate_mtd_pct = mtd_activated.positive? ? ((mtd_won.to_f / mtd_activated) * 100).round : nil
+    conversion_rate_ytd_pct = ytd_activated.positive? ? ((ytd_won.to_f / ytd_activated) * 100).round : nil
+
     owner_ids = @proposals.distinct.pluck(:owner_id)
     originators = User.where(id: owner_ids).includes(:tenant).map do |user|
       user_proposals = @proposals.where(owner_id: user.id)
@@ -74,6 +96,8 @@ class AnalyticsCalculator
       lost_count:               lost_count,
       in_campaign_count:        in_campaign_count,
       conversion_rate_pct:      conversion_rate_pct,
+      conversion_rate_mtd_pct:  conversion_rate_mtd_pct,
+      conversion_rate_ytd_pct:  conversion_rate_ytd_pct,
       closed_revenue:           closed_revenue,
       active_pipeline_value:    active_pipeline_value,
       follow_ups_sent:          follow_ups_sent,

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -13,6 +13,21 @@
         <div class="display-6 fw-semibold mb-1">
           <%= analytics.conversion_rate_pct.nil? ? "—" : "#{analytics.conversion_rate_pct}%" %>
         </div>
+        <%# SPEC-05 v1.0: MTD / YTD dual display inside the Conversion Rate tile. %>
+        <div class="d-flex gap-3 small mt-2 mb-2">
+          <div>
+            <span class="text-muted">MTD</span>
+            <span class="fw-semibold ms-1">
+              <%= analytics.conversion_rate_mtd_pct.nil? ? "—" : "#{analytics.conversion_rate_mtd_pct}%" %>
+            </span>
+          </div>
+          <div>
+            <span class="text-muted">YTD</span>
+            <span class="fw-semibold ms-1">
+              <%= analytics.conversion_rate_ytd_pct.nil? ? "—" : "#{analytics.conversion_rate_ytd_pct}%" %>
+            </span>
+          </div>
+        </div>
         <div class="small text-muted">Won jobs as a % of activated proposals</div>
       </div>
     </div>

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -39,4 +39,45 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
     assert_nil result.conversion_rate_pct
   end
+
+  # --- SPEC-05 v1.0 MTD/YTD --------------------------------------------
+
+  test "conversion_rate_mtd_pct is the won rate among activations created this month" do
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: :won, closed_at: Time.current.beginning_of_month + 1.hour, proposal_value: 5_000)
+    CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_month + 30.minutes)
+
+    other = job_proposals(:same_tenant_other_org)
+    other.update!(pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: other, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_month + 1.hour)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    # 1 won out of 2 activated this month → 50%
+    assert_equal 50, result.conversion_rate_mtd_pct
+  end
+
+  test "conversion_rate_ytd_pct counts only this year's activations and wins" do
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: :won, closed_at: Time.current.beginning_of_year + 1.day, proposal_value: 5_000)
+    CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_year + 1.hour)
+
+    # An activation from last year — should NOT count toward YTD
+    last_year_jp = job_proposals(:same_tenant_other_org)
+    last_year_jp.update!(pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: last_year_jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: 14.months.ago)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    # 1 won out of 1 activated YTD → 100%
+    assert_equal 100, result.conversion_rate_ytd_pct
+  end
+
+  test "conversion_rate_mtd_pct and ytd are nil when nothing has been activated" do
+    result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
+    assert_nil result.conversion_rate_mtd_pct
+    assert_nil result.conversion_rate_ytd_pct
+  end
 end


### PR DESCRIPTION
## Summary

PR 6 of 7. Closes #87. Adds MTD and YTD display to the Conversion Rate hero tile per SPEC-05 v1.0.

`AnalyticsCalculator` adds `conversion_rate_mtd_pct` and `conversion_rate_ytd_pct`. Dashboard tile renders both inline beneath the headline rate.

## Stack position

Base: `pr/logo-upload` (#161). Final PR (#163 branch comparison) branches from this.