### PR TITLE
Analytics: per-location Conversion Rate breakdown (SPEC-06)

### DIFF
--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -64,6 +64,30 @@ class AnalyticsCalculator
     conversion_rate_mtd_pct = mtd_activated.positive? ? ((mtd_won.to_f / mtd_activated) * 100).round : nil
     conversion_rate_ytd_pct = ytd_activated.positive? ? ((ytd_won.to_f / ytd_activated) * 100).round : nil
 
+    # SPEC-06 v1.0 — per-location Conversion Rate breakdown for the
+    # tile expand-toggle. Computed from the same proposals_scope so it
+    # respects whatever filter the caller applied. Empty array means
+    # don't render the toggle at all.
+    by_location = @proposals.where.not(location_id: nil)
+      .joins(:location)
+      .group("locations.id", "locations.display_name")
+      .pluck("locations.id", "locations.display_name", Arel.sql("COUNT(*)"))
+      .map do |loc_id, loc_name, total_in_loc|
+        loc_proposals = @proposals.where(location_id: loc_id)
+        activated = loc_proposals.joins(:campaign_instances).distinct.count
+        won = loc_proposals.where(pipeline_stage: :won).count
+        rate = activated.positive? ? ((won.to_f / activated) * 100).round : nil
+        {
+          location_id: loc_id,
+          location_display_name: loc_name,
+          activated_count: activated,
+          won_count: won,
+          conversion_rate_pct: rate,
+          total_proposals: total_in_loc
+        }
+      end
+      .sort_by { |row| row[:location_display_name].to_s }
+
     owner_ids = @proposals.distinct.pluck(:owner_id)
     originators = User.where(id: owner_ids).includes(:tenant).map do |user|
       user_proposals = @proposals.where(owner_id: user.id)
@@ -98,6 +122,7 @@ class AnalyticsCalculator
       conversion_rate_pct:      conversion_rate_pct,
       conversion_rate_mtd_pct:  conversion_rate_mtd_pct,
       conversion_rate_ytd_pct:  conversion_rate_ytd_pct,
+      conversion_rate_by_location: by_location,
       closed_revenue:           closed_revenue,
       active_pipeline_value:    active_pipeline_value,
       follow_ups_sent:          follow_ups_sent,

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -29,6 +29,43 @@
           </div>
         </div>
         <div class="small text-muted">Won jobs as a % of activated proposals</div>
+
+        <%# SPEC-06 v1.0: by-location breakdown.
+            Visible only to tenant admins / SMAI staff (operators scoped to
+            a single location see their own number above and don't need a
+            "by location" expansion). Hidden when the scope has 0 or 1
+            locations because there's nothing to compare. %>
+        <% if !current_user.scoped_to_location? && analytics.conversion_rate_by_location.size > 1 %>
+          <button class="btn btn-sm btn-link p-0 mt-2" type="button"
+                  data-bs-toggle="collapse" data-bs-target="#cr-by-location"
+                  aria-expanded="false" aria-controls="cr-by-location">
+            By location ›
+          </button>
+          <div class="collapse mt-2" id="cr-by-location">
+            <table class="table table-sm mb-0 small">
+              <thead class="table-light">
+                <tr>
+                  <th>Location</th>
+                  <th class="text-end">Won</th>
+                  <th class="text-end">Activated</th>
+                  <th class="text-end">Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% analytics.conversion_rate_by_location.each do |row| %>
+                  <tr>
+                    <td><%= row[:location_display_name] %></td>
+                    <td class="text-end"><%= row[:won_count] %></td>
+                    <td class="text-end"><%= row[:activated_count] %></td>
+                    <td class="text-end fw-semibold">
+                      <%= row[:conversion_rate_pct].nil? ? "—" : "#{row[:conversion_rate_pct]}%" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/test/controllers/analytics_controller_test.rb
+++ b/test/controllers/analytics_controller_test.rb
@@ -51,4 +51,43 @@ class AnalyticsControllerTest < ActionDispatch::IntegrationTest
     get analytics_url
     assert_match @user_one.tenant.name, response.body
   end
+
+  # --- SPEC-06 v1.0 by-location breakdown -------------------------------
+
+  test "tenant admin sees the By location toggle and per-location rows" do
+    tenant = tenants(:one)
+    location_a = locations(:ne_dallas)
+    location_b = tenant.locations.create!(
+      display_name: "South Dallas", address_line_1: "5 Side", city: "Dallas",
+      state: "TX", postal_code: "75002", phone_number: "(214) 555-0202", is_active: true
+    )
+    job_proposals(:in_users_org).update!(location: location_a)
+    job_proposals(:same_tenant_other_org).update!(location: location_b)
+
+    # @user_one has tenant: one with no location → tenant admin
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_match "By location", response.body
+    assert_match location_a.display_name, response.body
+    assert_match location_b.display_name, response.body
+  end
+
+  test "regular tenant user (scoped to a location) does not see the By location toggle" do
+    @user_one.update!(location: locations(:ne_dallas))
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_no_match "By location", response.body
+  end
+
+  test "tenant admin in a single-location tenant does not see the toggle (nothing to compare)" do
+    # tenant two has globex_main fixture; ensure their proposal lives there
+    job_proposals(:other_tenant).update!(location: locations(:globex_main))
+
+    sign_in @user_two
+    get analytics_url
+    assert_response :success
+    assert_no_match "By location", response.body
+  end
 end

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -80,4 +80,32 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     assert_nil result.conversion_rate_mtd_pct
     assert_nil result.conversion_rate_ytd_pct
   end
+
+  # --- SPEC-06 v1.0 by-location breakdown -------------------------------
+
+  test "conversion_rate_by_location returns one row per location with activated/won/rate" do
+    loc_a = locations(:ne_dallas)
+    loc_b = tenants(:one).locations.create!(
+      display_name: "South Dallas", address_line_1: "5 Side", city: "Dallas",
+      state: "TX", postal_code: "75002", phone_number: "(214) 555-0202", is_active: true
+    )
+    jp_a = job_proposals(:in_users_org)
+    jp_a.update!(location: loc_a, pipeline_stage: :won)
+    CampaignInstance.create!(host: jp_a, campaign: campaigns(:approved_campaign), status: :active)
+
+    jp_b = job_proposals(:same_tenant_other_org)
+    jp_b.update!(location: loc_b, pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: jp_b, campaign: campaigns(:approved_campaign), status: :active)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    rows = result.conversion_rate_by_location
+    by_name = rows.index_by { |r| r[:location_display_name] }
+    assert_equal 100, by_name["NE Dallas"][:conversion_rate_pct]
+    assert_equal 0,   by_name["South Dallas"][:conversion_rate_pct]
+  end
+
+  test "conversion_rate_by_location is empty when no proposals have a location" do
+    result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
+    assert_equal [], result.conversion_rate_by_location
+  end
 end


### PR DESCRIPTION
## Summary

PR 7 of 7 — final PR in the v0.1 - Happy Path stack. Closes #91.

`AnalyticsCalculator.conversion_rate_by_location` returns one row per Location in scope with activated/won counts and the rate. The dashboard renders a "By location ›" toggle inside the Conversion Rate hero tile that expands a Bootstrap collapse panel listing each location.

## Stack position

Base: `pr/analytics-mtd-ytd` (#162). **End of stack.**