### PR TITLE
v0.1 consolidated: schema reconciliation through analytics

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -8,6 +8,11 @@ class Admin::LocationsController < Admin::BaseController
   def create
     @location = @tenant.locations.build(location_params.merge(created_by_user: current_user))
     if @location.save
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "location.create", target: @location,
+        after: @location.slice(:display_name, :address_line_1, :address_line_2, :city, :state, :postal_code, :phone_number, :is_active)
+      )
       redirect_to admin_tenant_path(@tenant), notice: "Location added."
     else
       render :new, status: :unprocessable_content

--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -1,5 +1,7 @@
 class Admin::TenantsController < Admin::BaseController
-  before_action :set_tenant, only: [:show]
+  TENANT_PARAMS = %i[name company_name logo_url job_reference_required].freeze
+
+  before_action :set_tenant, only: [:show, :edit, :update]
 
   def index
     @tenants = Tenant.order(:name)
@@ -17,11 +19,33 @@ class Admin::TenantsController < Admin::BaseController
   end
 
   def create
-    @tenant = Tenant.new(name: params.dig(:tenant, :name))
+    @tenant = Tenant.new(tenant_params)
     if @tenant.save
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "tenant.create", target: @tenant,
+        after: tenant_audit_snapshot(@tenant)
+      )
       redirect_to admin_tenant_path(@tenant), notice: "Tenant '#{@tenant.name}' created."
     else
       render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    before = tenant_audit_snapshot(@tenant)
+    if @tenant.update(tenant_params)
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "tenant.update", target: @tenant,
+        before: before, after: tenant_audit_snapshot(@tenant)
+      )
+      redirect_to admin_tenant_path(@tenant), notice: "Tenant updated."
+    else
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -29,5 +53,13 @@ class Admin::TenantsController < Admin::BaseController
 
   def set_tenant
     @tenant = Tenant.find(params[:id])
+  end
+
+  def tenant_params
+    params.require(:tenant).permit(*TENANT_PARAMS)
+  end
+
+  def tenant_audit_snapshot(tenant)
+    tenant.slice(:name, :company_name, :logo_url, :job_reference_required)
   end
 end

--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -1,5 +1,5 @@
 class Admin::TenantsController < Admin::BaseController
-  TENANT_PARAMS = %i[name company_name logo_url job_reference_required].freeze
+  TENANT_PARAMS = %i[name company_name logo_url logo job_reference_required].freeze
 
   before_action :set_tenant, only: [:show, :edit, :update]
 
@@ -60,6 +60,9 @@ class Admin::TenantsController < Admin::BaseController
   end
 
   def tenant_audit_snapshot(tenant)
-    tenant.slice(:name, :company_name, :logo_url, :job_reference_required)
+    tenant.slice(:name, :company_name, :logo_url, :job_reference_required).merge(
+      logo_attached: tenant.logo.attached?,
+      logo_filename: tenant.logo.attached? ? tenant.logo.filename.to_s : nil
+    )
   end
 end

--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -67,11 +67,24 @@ class JobProposalsController < ApplicationController
       render :new, status: :unprocessable_content and return
     end
 
+    # location_id is NOT NULL and scenario_id is required for campaign
+    # readiness. Pre-populate sane defaults so the create succeeds; the
+    # operator can correct both on the edit form before approving.
+    default_location = current_user.location || current_user.tenant.locations.active.order(:id).first
+    default_scenario = current_user.tenant.activated_scenarios.includes(:job_type).order(:id).first ||
+                       Scenario.includes(:job_type).order(:id).first
+    if default_scenario.nil? || default_location.nil?
+      flash.now[:alert] = "Your tenant needs at least one active location and one activated scenario before a proposal can be created."
+      render :new, status: :unprocessable_content and return
+    end
+
     proposal = JobProposal.new(
       tenant: current_user.tenant,
-      location: current_user.location,
+      location: default_location,
       owner: current_user,
-      created_by_user: current_user
+      created_by_user: current_user,
+      job_type: default_scenario.job_type,
+      scenario: default_scenario
     )
     attachment = proposal.attachments.build(uploaded_by_user: current_user)
     attachment.file.attach(file)

--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -5,7 +5,7 @@ class JobProposalsController < ApplicationController
   EDITABLE_PARAMS = %i[
     customer_title customer_first_name customer_last_name customer_email
     customer_house_number customer_street customer_city customer_state customer_zip
-    internal_reference loss_notes loss_reason
+    internal_reference dash_job_number loss_notes loss_reason
     owner_id job_type_id scenario_id proposal_value
   ].freeze
 

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,0 +1,20 @@
+# Append-only record of a state-changing admin operation. Per PRD-10
+# v1.3.1 §10, every Admin Portal write goes through here so an SMAI
+# operator can answer "who changed what, when?"
+#
+# AuditLog rows are never updated or deleted; the Rails-side accessor is
+# read-only after creation.
+class AuditLog < ApplicationRecord
+  belongs_to :tenant
+  belongs_to :actor_user, class_name: "User", optional: true
+
+  validates :action, :target_type, :target_id, presence: true
+
+  before_update do
+    raise ActiveRecord::ReadOnlyRecord, "audit_logs is append-only"
+  end
+
+  before_destroy do
+    raise ActiveRecord::ReadOnlyRecord, "audit_logs is append-only"
+  end
+end

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -1,6 +1,6 @@
 class JobProposal < ApplicationRecord
   belongs_to :tenant
-  belongs_to :location, optional: true
+  belongs_to :location
   belongs_to :owner, class_name: "User"
   belongs_to :created_by_user, class_name: "User"
   belongs_to :closed_by_user, class_name: "User", optional: true
@@ -99,4 +99,5 @@ class JobProposal < ApplicationRecord
     joined = parts.reject(&:empty?).join(" ")
     joined.presence
   end
+
 end

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -15,6 +15,12 @@ class JobProposal < ApplicationRecord
        { in_campaign: "in_campaign", won: "won", lost: "lost" },
        prefix: true
 
+  # When the proposal's tenant requires a DASH-style job reference (per
+  # PRD-02 v1.5 §5 / PRD-10 v1.3.1 §7.5), require it before approving the
+  # proposal — but allow drafting and approving states to persist without
+  # one so the operator can fill it in on the edit form.
+  validate :dash_job_number_required_when_approved
+
   # Operator hasn't done their part yet on this proposal — it sits in
   # one of: drafting (not finished), approving (campaign drafted but
   # awaiting operator approval), or approved+in-campaign with an
@@ -100,4 +106,12 @@ class JobProposal < ApplicationRecord
     joined.presence
   end
 
+  private
+
+  def dash_job_number_required_when_approved
+    return unless tenant&.job_reference_required
+    return if dash_job_number.present?
+    return if status_drafting? || status_approving?
+    errors.add(:dash_job_number, "is required before this job can be approved")
+  end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -3,6 +3,13 @@ class Tenant < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :job_proposals, dependent: :destroy
   has_many :invitations, dependent: :destroy
+
+  # PRD-10 v1.3.1 §7 / SPEC-07 v1.4 §9 — every campaign email signature
+  # references the account's logo. Stored via Active Storage so SMAI staff
+  # (or eventually the operator UI) can upload via the admin portal. The
+  # string column `logo_url` is preserved as a manual override for tenants
+  # who'd rather link to a logo hosted elsewhere.
+  has_one_attached :logo
   has_many :tenant_job_types, dependent: :destroy
   has_many :tenant_scenarios, dependent: :destroy
 
@@ -21,4 +28,12 @@ class Tenant < ApplicationRecord
            source: :scenario
 
   validates :name, presence: true
+
+  # Resolves the right URL for templates / signatures: prefer the
+  # uploaded logo blob if attached, else the manual `logo_url` string,
+  # else nil. Callers handle the nil case.
+  def logo_image_url
+    return Rails.application.routes.url_helpers.rails_blob_url(logo, only_path: true) if logo.attached?
+    logo_url.presence
+  end
 end

--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -64,6 +64,30 @@ class AnalyticsCalculator
     conversion_rate_mtd_pct = mtd_activated.positive? ? ((mtd_won.to_f / mtd_activated) * 100).round : nil
     conversion_rate_ytd_pct = ytd_activated.positive? ? ((ytd_won.to_f / ytd_activated) * 100).round : nil
 
+    # SPEC-06 v1.0 — per-location Conversion Rate breakdown for the
+    # tile expand-toggle. Computed from the same proposals_scope so it
+    # respects whatever filter the caller applied. Empty array means
+    # don't render the toggle at all.
+    by_location = @proposals.where.not(location_id: nil)
+      .joins(:location)
+      .group("locations.id", "locations.display_name")
+      .pluck("locations.id", "locations.display_name", Arel.sql("COUNT(*)"))
+      .map do |loc_id, loc_name, total_in_loc|
+        loc_proposals = @proposals.where(location_id: loc_id)
+        activated = loc_proposals.joins(:campaign_instances).distinct.count
+        won = loc_proposals.where(pipeline_stage: :won).count
+        rate = activated.positive? ? ((won.to_f / activated) * 100).round : nil
+        {
+          location_id: loc_id,
+          location_display_name: loc_name,
+          activated_count: activated,
+          won_count: won,
+          conversion_rate_pct: rate,
+          total_proposals: total_in_loc
+        }
+      end
+      .sort_by { |row| row[:location_display_name].to_s }
+
     owner_ids = @proposals.distinct.pluck(:owner_id)
     originators = User.where(id: owner_ids).includes(:tenant).map do |user|
       user_proposals = @proposals.where(owner_id: user.id)
@@ -98,6 +122,7 @@ class AnalyticsCalculator
       conversion_rate_pct:      conversion_rate_pct,
       conversion_rate_mtd_pct:  conversion_rate_mtd_pct,
       conversion_rate_ytd_pct:  conversion_rate_ytd_pct,
+      conversion_rate_by_location: by_location,
       closed_revenue:           closed_revenue,
       active_pipeline_value:    active_pipeline_value,
       follow_ups_sent:          follow_ups_sent,

--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -42,6 +42,28 @@ class AnalyticsCalculator
 
     conversion_rate_pct = activated_count.positive? ? ((won_count.to_f / activated_count) * 100).round : nil
 
+    # MTD/YTD breakdown for the Conversion Rate hero tile per SPEC-05 v1.0.
+    # Activated count is bucketed by the campaign instance's created_at;
+    # won count is bucketed by the proposal's closed_at (set when the
+    # pipeline_stage flipped to won or lost).
+    now = Time.current
+    mtd_start = now.beginning_of_month
+    ytd_start = now.beginning_of_year
+
+    mtd_activated = @proposals
+      .joins(:campaign_instances)
+      .where("campaign_instances.created_at >= ?", mtd_start)
+      .distinct.count
+    ytd_activated = @proposals
+      .joins(:campaign_instances)
+      .where("campaign_instances.created_at >= ?", ytd_start)
+      .distinct.count
+    mtd_won = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", mtd_start).count
+    ytd_won = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", ytd_start).count
+
+    conversion_rate_mtd_pct = mtd_activated.positive? ? ((mtd_won.to_f / mtd_activated) * 100).round : nil
+    conversion_rate_ytd_pct = ytd_activated.positive? ? ((ytd_won.to_f / ytd_activated) * 100).round : nil
+
     owner_ids = @proposals.distinct.pluck(:owner_id)
     originators = User.where(id: owner_ids).includes(:tenant).map do |user|
       user_proposals = @proposals.where(owner_id: user.id)
@@ -74,6 +96,8 @@ class AnalyticsCalculator
       lost_count:               lost_count,
       in_campaign_count:        in_campaign_count,
       conversion_rate_pct:      conversion_rate_pct,
+      conversion_rate_mtd_pct:  conversion_rate_mtd_pct,
+      conversion_rate_ytd_pct:  conversion_rate_ytd_pct,
       closed_revenue:           closed_revenue,
       active_pipeline_value:    active_pipeline_value,
       follow_ups_sent:          follow_ups_sent,

--- a/app/services/audit_logger.rb
+++ b/app/services/audit_logger.rb
@@ -1,0 +1,20 @@
+# Thin helper for writing AuditLog rows from controllers/services. Per
+# PRD-10 v1.3.1 §10, every state-changing admin operation goes through
+# here so the audit trail stays uniform.
+#
+# Usage:
+#   AuditLogger.write(tenant: @tenant, actor: current_user,
+#                     action: "tenant.update", target: @tenant,
+#                     before: { name: old_name }, after: { name: new_name })
+class AuditLogger
+  def self.write(tenant:, actor:, action:, target:, before: nil, after: nil)
+    AuditLog.create!(
+      tenant: tenant,
+      actor_user: actor,
+      action: action,
+      target_type: target.class.name,
+      target_id: target.id,
+      payload: { before: before, after: after }.compact
+    )
+  end
+end

--- a/app/services/mail_generator.rb
+++ b/app/services/mail_generator.rb
@@ -205,7 +205,7 @@ class MailGenerator
     when "originator_title"       then originator&.title
     when "originator_phone"       then originator&.phone_number
     when "originator_email"       then originator&.email
-    when "company_name"           then tenant&.name
+    when "company_name"           then tenant&.company_name.presence || tenant&.name
     when "company_phone"          then location&.phone_number
     when "location_name"          then location&.display_name
     when "location_address"       then location_address

--- a/app/services/mail_generator.rb
+++ b/app/services/mail_generator.rb
@@ -134,6 +134,17 @@ class MailGenerator
     end
   end
 
+  # When the proposal carries a DASH job number, prefix it on the email
+  # subject so Jeff's DASH inbox can thread on it (CC-06 v1.2 §1; PRD-02
+  # v1.5 §5). Idempotent — if the subject already starts with the same
+  # prefix (e.g., the operator hand-edited a draft body), don't double up.
+  def self.prefix_dash_job_number(subject, dash_job_number)
+    return subject if dash_job_number.blank?
+    prefix = "[DASH-#{dash_job_number}]"
+    return subject if subject.to_s.start_with?(prefix)
+    "#{prefix} #{subject}".strip
+  end
+
   # Appends a standard sign-off block to every email body so individual
   # campaign templates don't have to repeat (and drift on) the
   # "name / phone / email / org" pattern. Built from already-resolved
@@ -172,6 +183,7 @@ class MailGenerator
       raise UnresolvedMergeFieldError, "Unresolved merge fields: #{unresolved.join(", ")}"
     end
 
+    subject = self.class.prefix_dash_job_number(subject, @job_proposal.dash_job_number)
     body = self.class.append_signature(body, values)
     Output.new(subject:, body:)
   end

--- a/app/views/admin/tenants/edit.html.erb
+++ b/app/views/admin/tenants/edit.html.erb
@@ -6,7 +6,7 @@
 
 <h1 class="h3 mb-3">Edit Tenant: <%= @tenant.name %></h1>
 
-<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true do |f| %>
+<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true, html: { multipart: true } do |f| %>
   <% if @tenant.errors.any? %>
     <div class="alert alert-danger">
       <strong>Please fix the following:</strong>
@@ -33,9 +33,21 @@
       </div>
 
       <div class="mb-3">
-        <%= f.label :logo_url, "Logo URL", class: "form-label" %>
+        <%= f.label :logo, "Logo (upload)", class: "form-label" %>
+        <% if @tenant.logo.attached? %>
+          <div class="mb-2">
+            <%= image_tag rails_blob_url(@tenant.logo, only_path: true), alt: "Current logo", style: "max-height: 64px;" %>
+            <div class="text-muted small mt-1"><%= @tenant.logo.filename %></div>
+          </div>
+        <% end %>
+        <%= f.file_field :logo, class: "form-control", accept: "image/*" %>
+        <div class="form-text">PNG, JPG, or SVG. Replaces any existing upload.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :logo_url, "Logo URL (manual override)", class: "form-label" %>
         <%= f.url_field :logo_url, class: "form-control", placeholder: "https://…" %>
-        <div class="form-text">Public URL of the logo. The upload pipeline lands separately.</div>
+        <div class="form-text">Used when no file is uploaded — link to a logo hosted elsewhere.</div>
       </div>
 
       <div class="form-check mb-0">

--- a/app/views/admin/tenants/edit.html.erb
+++ b/app/views/admin/tenants/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title, "Edit Tenant: #{@tenant.name}" %>
+
+<%= render "shared/admin_breadcrumb",
+      tenant: @tenant,
+      current: :tenant %>
+
+<h1 class="h3 mb-3">Edit Tenant: <%= @tenant.name %></h1>
+
+<%= form_with model: @tenant, url: admin_tenant_path(@tenant), method: :patch, local: true do |f| %>
+  <% if @tenant.errors.any? %>
+    <div class="alert alert-danger">
+      <strong>Please fix the following:</strong>
+      <ul class="mb-0">
+        <% @tenant.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <div class="mb-3">
+        <%= f.label :name, "Account name (internal)", class: "form-label" %>
+        <%= f.text_field :name, class: "form-control", required: true %>
+        <div class="form-text">Shown in SMAI admin only.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :company_name, "Company name (customer-facing)", class: "form-label" %>
+        <%= f.text_field :company_name, class: "form-control", placeholder: @tenant.name %>
+        <div class="form-text">Used in email signatures (<code>{company_name}</code>). Falls back to the account name when blank.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :logo_url, "Logo URL", class: "form-label" %>
+        <%= f.url_field :logo_url, class: "form-control", placeholder: "https://…" %>
+        <div class="form-text">Public URL of the logo. The upload pipeline lands separately.</div>
+      </div>
+
+      <div class="form-check mb-0">
+        <%= f.check_box :job_reference_required, class: "form-check-input", id: "tenant-job-ref-required" %>
+        <%= f.label :job_reference_required, "Require DASH job number", class: "form-check-label", for: "tenant-job-ref-required" %>
+        <div class="form-text">When on, every job in this account needs a DASH number before it can be approved.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit "Save", class: "btn btn-primary" %>
+    <%= link_to "Cancel", admin_tenant_path(@tenant), class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -19,9 +19,16 @@
 
       <dt class="col-sm-3">Logo</dt>
       <dd class="col-sm-9">
-        <% if @tenant.logo_url.present? %>
-          <%= image_tag @tenant.logo_url, alt: "Logo", style: "max-height: 48px;" %>
-          <div class="text-muted small mt-1"><%= @tenant.logo_url %></div>
+        <% logo_src = @tenant.logo_image_url %>
+        <% if logo_src.present? %>
+          <%= image_tag logo_src, alt: "Logo", style: "max-height: 48px;" %>
+          <div class="text-muted small mt-1">
+            <% if @tenant.logo.attached? %>
+              Uploaded · <%= @tenant.logo.filename %>
+            <% else %>
+              <%= @tenant.logo_url %>
+            <% end %>
+          </div>
         <% else %>
           <span class="text-muted">— Not set</span>
         <% end %>

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -3,8 +3,39 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h1 class="h3 mb-0">Tenant: <%= @tenant.name %></h1>
   <div class="d-flex gap-2">
+    <%= link_to "Edit", edit_admin_tenant_path(@tenant), class: "btn btn-sm btn-outline-primary" %>
     <%= link_to "Manage activations", admin_tenant_activations_path(@tenant), class: "btn btn-sm btn-outline-primary" %>
     <%= link_to "All tenants", admin_tenants_path, class: "btn btn-sm btn-outline-secondary" %>
+  </div>
+</div>
+
+<div class="card shadow-sm mb-3">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Company name</dt>
+      <dd class="col-sm-9">
+        <%= @tenant.company_name.presence || content_tag(:span, @tenant.name + " (defaulted from account name)", class: "text-muted") %>
+      </dd>
+
+      <dt class="col-sm-3">Logo</dt>
+      <dd class="col-sm-9">
+        <% if @tenant.logo_url.present? %>
+          <%= image_tag @tenant.logo_url, alt: "Logo", style: "max-height: 48px;" %>
+          <div class="text-muted small mt-1"><%= @tenant.logo_url %></div>
+        <% else %>
+          <span class="text-muted">— Not set</span>
+        <% end %>
+      </dd>
+
+      <dt class="col-sm-3">DASH job # required</dt>
+      <dd class="col-sm-9">
+        <% if @tenant.job_reference_required %>
+          <span class="badge text-bg-info">Required</span>
+        <% else %>
+          <span class="text-muted">No</span>
+        <% end %>
+      </dd>
+    </dl>
   </div>
 </div>
 

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -13,6 +13,21 @@
         <div class="display-6 fw-semibold mb-1">
           <%= analytics.conversion_rate_pct.nil? ? "—" : "#{analytics.conversion_rate_pct}%" %>
         </div>
+        <%# SPEC-05 v1.0: MTD / YTD dual display inside the Conversion Rate tile. %>
+        <div class="d-flex gap-3 small mt-2 mb-2">
+          <div>
+            <span class="text-muted">MTD</span>
+            <span class="fw-semibold ms-1">
+              <%= analytics.conversion_rate_mtd_pct.nil? ? "—" : "#{analytics.conversion_rate_mtd_pct}%" %>
+            </span>
+          </div>
+          <div>
+            <span class="text-muted">YTD</span>
+            <span class="fw-semibold ms-1">
+              <%= analytics.conversion_rate_ytd_pct.nil? ? "—" : "#{analytics.conversion_rate_ytd_pct}%" %>
+            </span>
+          </div>
+        </div>
         <div class="small text-muted">Won jobs as a % of activated proposals</div>
       </div>
     </div>

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -29,6 +29,43 @@
           </div>
         </div>
         <div class="small text-muted">Won jobs as a % of activated proposals</div>
+
+        <%# SPEC-06 v1.0: by-location breakdown.
+            Visible only to tenant admins / SMAI staff (operators scoped to
+            a single location see their own number above and don't need a
+            "by location" expansion). Hidden when the scope has 0 or 1
+            locations because there's nothing to compare. %>
+        <% if !current_user.scoped_to_location? && analytics.conversion_rate_by_location.size > 1 %>
+          <button class="btn btn-sm btn-link p-0 mt-2" type="button"
+                  data-bs-toggle="collapse" data-bs-target="#cr-by-location"
+                  aria-expanded="false" aria-controls="cr-by-location">
+            By location ›
+          </button>
+          <div class="collapse mt-2" id="cr-by-location">
+            <table class="table table-sm mb-0 small">
+              <thead class="table-light">
+                <tr>
+                  <th>Location</th>
+                  <th class="text-end">Won</th>
+                  <th class="text-end">Activated</th>
+                  <th class="text-end">Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% analytics.conversion_rate_by_location.each do |row| %>
+                  <tr>
+                    <td><%= row[:location_display_name] %></td>
+                    <td class="text-end"><%= row[:won_count] %></td>
+                    <td class="text-end"><%= row[:activated_count] %></td>
+                    <td class="text-end fw-semibold">
+                      <%= row[:conversion_rate_pct].nil? ? "—" : "#{row[:conversion_rate_pct]}%" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/job_proposals/edit.html.erb
+++ b/app/views/job_proposals/edit.html.erb
@@ -108,6 +108,15 @@
           <%= f.label :internal_reference, "Internal reference", class: "form-label" %>
           <%= f.text_field :internal_reference, class: "form-control", disabled: @campaign_in_flight %>
         </div>
+        <% if @job_proposal.tenant&.job_reference_required %>
+          <div class="col-md-6">
+            <%= f.label :dash_job_number, "DASH job number", class: "form-label" %>
+            <%= f.text_field :dash_job_number, class: "form-control", disabled: @campaign_in_flight,
+                  required: !@job_proposal.status_drafting?,
+                  placeholder: "e.g. 12345" %>
+            <div class="form-text">Required before this job can be approved. Prefixed onto every campaign email subject so the thread stays threaded in DASH.</div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     resources :integrations, only: [:index] do
       collection { post :check }
     end
-    resources :tenants, only: [:index, :show, :new, :create] do
+    resources :tenants, only: [:index, :show, :new, :create, :edit, :update] do
       resources :invitations, only: [:create, :destroy]
       resources :locations, only: [:new, :create]
       resource :activations, only: [:show], controller: "activations"

--- a/db/migrate/20260508235849_reconcile_job_proposal_schema.rb
+++ b/db/migrate/20260508235849_reconcile_job_proposal_schema.rb
@@ -1,0 +1,47 @@
+class ReconcileJobProposalSchema < ActiveRecord::Migration[8.1]
+  def up
+    # Add template_version_id on campaigns per PRD-01 §5 / SPEC-11 v2.0 §7.3.
+    # String for now — there's no template_versions table yet (separate PR).
+    add_column :campaigns, :template_version_id, :string
+
+    # Backfill nil location_id with the proposal's tenant's first active
+    # location. Then lock NOT NULL.
+    execute <<~SQL
+      UPDATE job_proposals AS jp
+         SET location_id = sub.id
+        FROM (
+          SELECT DISTINCT ON (tenant_id) id, tenant_id
+            FROM locations
+           WHERE is_active = true
+           ORDER BY tenant_id, id
+        ) AS sub
+       WHERE jp.tenant_id = sub.tenant_id
+         AND jp.location_id IS NULL
+    SQL
+
+    nil_location = connection.select_value("SELECT COUNT(*) FROM job_proposals WHERE location_id IS NULL").to_i
+    if nil_location.positive?
+      raise "Refusing to lock location_id NOT NULL: #{nil_location} proposals still have nil location_id"
+    end
+    change_column_null :job_proposals, :location_id, false
+
+    # `scenario_key` is being removed in favor of the FK `scenario_id`
+    # (which is the AR-native source of truth). Before dropping the
+    # column, backfill any proposal that has a scenario_key but a nil
+    # scenario_id by looking up the scenario whose code matches.
+    execute <<~SQL
+      UPDATE job_proposals AS jp
+         SET scenario_id = s.id
+        FROM scenarios s
+       WHERE s.code = jp.scenario_key
+         AND jp.scenario_id IS NULL
+         AND jp.scenario_key IS NOT NULL
+    SQL
+
+    remove_column :job_proposals, :scenario_key
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Schema reconciliation is one-way."
+  end
+end

--- a/db/migrate/20260509000505_add_dash_job_number_support.rb
+++ b/db/migrate/20260509000505_add_dash_job_number_support.rb
@@ -1,0 +1,7 @@
+class AddDashJobNumberSupport < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenants, :job_reference_required, :boolean, null: false, default: false
+    add_column :job_proposals, :dash_job_number, :string
+    add_index :job_proposals, :dash_job_number
+  end
+end

--- a/db/migrate/20260509001343_add_tenant_account_fields_and_audit_logs.rb
+++ b/db/migrate/20260509001343_add_tenant_account_fields_and_audit_logs.rb
@@ -1,0 +1,20 @@
+class AddTenantAccountFieldsAndAuditLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenants, :logo_url, :string
+    add_column :tenants, :company_name, :string
+
+    create_table :audit_logs do |t|
+      t.references :tenant, null: false, foreign_key: true
+      t.references :actor_user, foreign_key: { to_table: :users }, null: true
+      t.string :action, null: false
+      t.string :target_type, null: false
+      t.bigint :target_id, null: false
+      t.jsonb :payload, null: false, default: {}
+      t.datetime :created_at, null: false
+
+      t.index [:target_type, :target_id]
+      t.index :action
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
     t.text "refresh_token"
     t.text "scopes"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "audit_logs", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "actor_user_id"
+    t.datetime "created_at", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
+    t.bigint "tenant_id", null: false
+    t.index ["action"], name: "index_audit_logs_on_action"
+    t.index ["actor_user_id"], name: "index_audit_logs_on_actor_user_id"
+    t.index ["created_at"], name: "index_audit_logs_on_created_at"
+    t.index ["target_type", "target_id"], name: "index_audit_logs_on_target_type_and_target_id"
+    t.index ["tenant_id"], name: "index_audit_logs_on_tenant_id"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -334,8 +349,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
   end
 
   create_table "tenants", force: :cascade do |t|
+    t.string "company_name"
     t.datetime "created_at", null: false
     t.boolean "job_reference_required", default: false, null: false
+    t.string "logo_url"
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
@@ -383,6 +400,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "audit_logs", "tenants"
+  add_foreign_key "audit_logs", "users", column: "actor_user_id"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_000505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,27 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "expires_at"
-    t.bigint "location_id"
     t.string "provider", default: "google", null: false
     t.text "refresh_token"
     t.text "scopes"
     t.datetime "updated_at", null: false
-    t.index ["location_id"], name: "index_application_mailboxes_on_location_id", unique: true, where: "(location_id IS NOT NULL)"
-  end
-
-  create_table "audit_logs", force: :cascade do |t|
-    t.string "action", null: false
-    t.bigint "actor_user_id"
-    t.datetime "created_at", null: false
-    t.jsonb "payload", default: {}, null: false
-    t.bigint "target_id", null: false
-    t.string "target_type", null: false
-    t.bigint "tenant_id", null: false
-    t.index ["action"], name: "index_audit_logs_on_action"
-    t.index ["actor_user_id"], name: "index_audit_logs_on_actor_user_id"
-    t.index ["created_at"], name: "index_audit_logs_on_created_at"
-    t.index ["target_type", "target_id"], name: "index_audit_logs_on_target_type_and_target_id"
-    t.index ["tenant_id"], name: "index_audit_logs_on_tenant_id"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -351,10 +334,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   end
 
   create_table "tenants", force: :cascade do |t|
-    t.string "company_name"
     t.datetime "created_at", null: false
     t.boolean "job_reference_required", default: false, null: false
-    t.string "logo_url"
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
@@ -402,9 +383,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "application_mailboxes", "locations"
-  add_foreign_key "audit_logs", "tenants"
-  add_foreign_key "audit_logs", "users", column: "actor_user_id"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,10 +47,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.datetime "expires_at"
+    t.bigint "location_id"
     t.string "provider", default: "google", null: false
     t.text "refresh_token"
     t.text "scopes"
     t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_application_mailboxes_on_location_id", unique: true, where: "(location_id IS NOT NULL)"
+  end
+
+  create_table "audit_logs", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "actor_user_id"
+    t.datetime "created_at", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
+    t.bigint "tenant_id", null: false
+    t.index ["action"], name: "index_audit_logs_on_action"
+    t.index ["actor_user_id"], name: "index_audit_logs_on_actor_user_id"
+    t.index ["created_at"], name: "index_audit_logs_on_created_at"
+    t.index ["target_type", "target_id"], name: "index_audit_logs_on_target_type_and_target_id"
+    t.index ["tenant_id"], name: "index_audit_logs_on_tenant_id"
   end
 
   create_table "campaign_instances", force: :cascade do |t|
@@ -106,6 +123,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
     t.datetime "paused_at"
     t.bigint "paused_by_user_id"
     t.integer "status", default: 0, null: false
+    t.string "template_version_id"
     t.datetime "updated_at", null: false
     t.index ["approved_by_user_id"], name: "index_campaigns_on_approved_by_user_id"
     t.index ["attributed_to_type", "attributed_to_id"], name: "index_campaigns_on_attributed_to"
@@ -187,18 +205,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
     t.string "customer_street"
     t.string "customer_title"
     t.string "customer_zip"
+    t.string "dash_job_number"
     t.string "internal_reference"
     t.text "job_description"
     t.bigint "job_type_id"
     t.jsonb "last_reply"
-    t.bigint "location_id"
+    t.bigint "location_id", null: false
     t.text "loss_notes"
     t.string "loss_reason"
     t.bigint "owner_id", null: false
     t.string "pipeline_stage"
     t.decimal "proposal_value", precision: 12, scale: 2
     t.bigint "scenario_id"
-    t.string "scenario_key"
     t.integer "status", default: 0, null: false
     t.string "status_details"
     t.string "status_overlay"
@@ -206,6 +224,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
     t.datetime "updated_at", null: false
     t.index ["closed_by_user_id"], name: "index_job_proposals_on_closed_by_user_id"
     t.index ["created_by_user_id"], name: "index_job_proposals_on_created_by_user_id"
+    t.index ["dash_job_number"], name: "index_job_proposals_on_dash_job_number"
     t.index ["job_type_id"], name: "index_job_proposals_on_job_type_id"
     t.index ["location_id"], name: "index_job_proposals_on_location_id"
     t.index ["owner_id"], name: "index_job_proposals_on_owner_id"
@@ -332,7 +351,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
   end
 
   create_table "tenants", force: :cascade do |t|
+    t.string "company_name"
     t.datetime "created_at", null: false
+    t.boolean "job_reference_required", default: false, null: false
+    t.string "logo_url"
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
@@ -380,6 +402,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_234028) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "application_mailboxes", "locations"
+  add_foreign_key "audit_logs", "tenants"
+  add_foreign_key "audit_logs", "users", column: "actor_user_id"
   add_foreign_key "campaign_instances", "campaigns"
   add_foreign_key "campaign_step_instances", "campaign_instances"
   add_foreign_key "campaign_step_instances", "campaign_steps"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,10 +70,9 @@ end
 
 # --- Demo job proposals -----------------------------------------------------
 # Wired to the restoration job types and the scenario codes seeded above.
-# `scenario_key` matches Scenario#code (per SPEC-07 / SPEC-11). Pipeline
-# stages and overlays follow PRD-01 v1.4.1 §10: in_campaign + optional
-# overlay (paused, customer_waiting, delivery_issue) for active jobs;
-# won / lost for terminal jobs.
+# Pipeline stages and overlays follow PRD-01 v1.4.1 §10: in_campaign +
+# optional overlay (paused, customer_waiting, delivery_issue) for active
+# jobs; won / lost for terminal jobs.
 
 DEMO_PROPOSALS = [
   # --- Water mitigation -----------------------------------------------------
@@ -225,7 +224,6 @@ DEMO_PROPOSALS.each_with_index do |row, i|
   proposal.created_by_user = (i.even? ? demo_owner : admin)
   proposal.job_type = scenario.job_type
   proposal.scenario = scenario
-  proposal.scenario_key = scenario.code
   proposal.customer_first_name = row[:first]
   proposal.customer_last_name = row[:last]
   proposal.customer_title = row[:title]

--- a/test/controllers/admin/job_proposals_controller_test.rb
+++ b/test/controllers/admin/job_proposals_controller_test.rb
@@ -39,6 +39,8 @@ class Admin::JobProposalsControllerTest < ActionDispatch::IntegrationTest
       post admin_job_proposals_url, params: {
         job_proposal: {
           tenant_id: @tenant.id,
+          location_id: locations(:ne_dallas).id,
+          scenario_id: scenarios(:sewage_backup).id,
           owner_id: @owner.id,
           customer_first_name: "Manual",
           customer_last_name: "Entry",
@@ -54,6 +56,7 @@ class Admin::JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @admin, jp.created_by_user
     assert_equal @owner, jp.owner
     assert_equal "Manual", jp.customer_first_name
+    assert_equal scenarios(:sewage_backup), jp.scenario
   end
 
   test "admin create re-renders the form when validations fail" do

--- a/test/controllers/admin/locations_controller_test.rb
+++ b/test/controllers/admin/locations_controller_test.rb
@@ -39,13 +39,18 @@ class Admin::LocationsControllerTest < ActionDispatch::IntegrationTest
   test "create persists a location under the tenant and stamps created_by" do
     sign_in @admin
     assert_difference -> { Location.count }, 1 do
-      post admin_tenant_locations_url(@tenant), params: valid_params
+      assert_difference -> { AuditLog.count }, 1 do
+        post admin_tenant_locations_url(@tenant), params: valid_params
+      end
     end
     assert_redirected_to admin_tenant_path(@tenant)
     location = @tenant.locations.find_by(display_name: "Boise")
     refute_nil location
     assert_equal "ID", location.state
     assert_equal @admin, location.created_by_user
+    log = AuditLog.where(target_type: "Location", target_id: location.id, action: "location.create").last
+    assert_equal @admin, log.actor_user
+    assert_equal "Boise", log.payload["after"]["display_name"]
   end
 
   test "create rejects invalid input without saving" do

--- a/test/controllers/admin/tenants_controller_test.rb
+++ b/test/controllers/admin/tenants_controller_test.rb
@@ -78,6 +78,20 @@ class Admin::TenantsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Servpro of NE Dallas", log.payload["after"]["company_name"]
   end
 
+  test "update accepts a logo file upload via Active Storage" do
+    sign_in @admin
+    tenant = tenants(:one)
+    file = Rack::Test::UploadedFile.new(StringIO.new("fake image bytes"), "image/png", original_filename: "logo.png")
+
+    assert_difference "ActiveStorage::Attachment.count", 1 do
+      patch admin_tenant_url(tenant), params: { tenant: { name: tenant.name, logo: file } }
+    end
+    assert_redirected_to admin_tenant_path(tenant)
+    tenant.reload
+    assert tenant.logo.attached?
+    assert_equal "logo.png", tenant.logo.filename.to_s
+  end
+
   test "non-admin can't edit or update a tenant" do
     sign_in @non_admin
     get edit_admin_tenant_url(tenants(:one))

--- a/test/controllers/admin/tenants_controller_test.rb
+++ b/test/controllers/admin/tenants_controller_test.rb
@@ -48,6 +48,47 @@ class Admin::TenantsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='invitation[email]']"
   end
 
+  test "edit renders the form" do
+    sign_in @admin
+    get edit_admin_tenant_url(tenants(:one))
+    assert_response :success
+    assert_select "input[name='tenant[name]']"
+    assert_select "input[name='tenant[company_name]']"
+    assert_select "input[name='tenant[logo_url]']"
+    assert_select "input[name='tenant[job_reference_required]']"
+  end
+
+  test "update writes an audit log entry capturing the change" do
+    sign_in @admin
+    tenant = tenants(:one)
+    assert_difference "AuditLog.count", 1 do
+      patch admin_tenant_url(tenant), params: { tenant: {
+        name: tenant.name,
+        company_name: "Servpro of NE Dallas",
+        logo_url: "https://example.com/logo.png",
+        job_reference_required: "1"
+      } }
+    end
+    assert_redirected_to admin_tenant_path(tenant)
+    tenant.reload
+    assert_equal "Servpro of NE Dallas", tenant.company_name
+    assert tenant.job_reference_required
+    log = AuditLog.where(target_type: "Tenant", target_id: tenant.id, action: "tenant.update").last
+    assert_equal @admin, log.actor_user
+    assert_equal "Servpro of NE Dallas", log.payload["after"]["company_name"]
+  end
+
+  test "non-admin can't edit or update a tenant" do
+    sign_in @non_admin
+    get edit_admin_tenant_url(tenants(:one))
+    assert_redirected_to root_path
+
+    assert_no_difference "AuditLog.count" do
+      patch admin_tenant_url(tenants(:one)), params: { tenant: { name: "Hacked" } }
+    end
+    assert_redirected_to root_path
+  end
+
   test "show replaces the invitation form with a warning when the mailbox isn't connected" do
     sign_in @admin
     get admin_tenant_url(tenants(:one))

--- a/test/controllers/analytics_controller_test.rb
+++ b/test/controllers/analytics_controller_test.rb
@@ -51,4 +51,43 @@ class AnalyticsControllerTest < ActionDispatch::IntegrationTest
     get analytics_url
     assert_match @user_one.tenant.name, response.body
   end
+
+  # --- SPEC-06 v1.0 by-location breakdown -------------------------------
+
+  test "tenant admin sees the By location toggle and per-location rows" do
+    tenant = tenants(:one)
+    location_a = locations(:ne_dallas)
+    location_b = tenant.locations.create!(
+      display_name: "South Dallas", address_line_1: "5 Side", city: "Dallas",
+      state: "TX", postal_code: "75002", phone_number: "(214) 555-0202", is_active: true
+    )
+    job_proposals(:in_users_org).update!(location: location_a)
+    job_proposals(:same_tenant_other_org).update!(location: location_b)
+
+    # @user_one has tenant: one with no location → tenant admin
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_match "By location", response.body
+    assert_match location_a.display_name, response.body
+    assert_match location_b.display_name, response.body
+  end
+
+  test "regular tenant user (scoped to a location) does not see the By location toggle" do
+    @user_one.update!(location: locations(:ne_dallas))
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_no_match "By location", response.body
+  end
+
+  test "tenant admin in a single-location tenant does not see the toggle (nothing to compare)" do
+    # tenant two has globex_main fixture; ensure their proposal lives there
+    job_proposals(:other_tenant).update!(location: locations(:globex_main))
+
+    sign_in @user_two
+    get analytics_url
+    assert_response :success
+    assert_no_match "By location", response.body
+  end
 end

--- a/test/fixtures/job_proposals.yml
+++ b/test/fixtures/job_proposals.yml
@@ -3,6 +3,7 @@
 # In tenant one — visible to user :one (same tenant).
 in_users_org:
   tenant: one
+  location: ne_dallas
   owner: one
   created_by_user: one
   job_type: one
@@ -14,6 +15,7 @@ in_users_org:
 # Also in tenant one — visible to user :one.
 same_tenant_other_org:
   tenant: one
+  location: ne_dallas
   owner: one
   created_by_user: one
   customer_first_name: Bob
@@ -24,6 +26,7 @@ same_tenant_other_org:
 # In tenant two — visible to user :two only.
 other_tenant:
   tenant: two
+  location: globex_main
   owner: two
   created_by_user: two
   customer_first_name: Carol

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -9,3 +9,13 @@ ne_dallas:
   postal_code: "75238"
   phone_number: "(214) 343-3973"
   is_active: true
+
+globex_main:
+  tenant: two
+  display_name: Globex Main
+  address_line_1: 1 Globex Way
+  city: Springfield
+  state: IL
+  postal_code: "62701"
+  phone_number: "(217) 555-0100"
+  is_active: true

--- a/test/models/audit_log_test.rb
+++ b/test/models/audit_log_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class AuditLogTest < ActiveSupport::TestCase
+  setup do
+    @tenant = tenants(:one)
+    @actor = users(:admin)
+  end
+
+  test "valid with required fields" do
+    log = AuditLog.new(
+      tenant: @tenant, actor_user: @actor,
+      action: "tenant.update", target_type: "Tenant", target_id: @tenant.id,
+      payload: { before: { name: "old" }, after: { name: "new" } }
+    )
+    assert log.valid?
+  end
+
+  test "rejects updates after creation" do
+    log = AuditLog.create!(
+      tenant: @tenant, action: "x", target_type: "Tenant", target_id: @tenant.id
+    )
+    assert_raises(ActiveRecord::ReadOnlyRecord) { log.update!(action: "y") }
+  end
+
+  test "rejects destroy" do
+    log = AuditLog.create!(
+      tenant: @tenant, action: "x", target_type: "Tenant", target_id: @tenant.id
+    )
+    assert_raises(ActiveRecord::ReadOnlyRecord) { log.destroy }
+  end
+end
+
+class AuditLoggerTest < ActiveSupport::TestCase
+  test "writes an audit log row with before/after" do
+    tenant = tenants(:one)
+    actor = users(:admin)
+    assert_difference "AuditLog.count", 1 do
+      AuditLogger.write(
+        tenant: tenant, actor: actor,
+        action: "tenant.update", target: tenant,
+        before: { name: "Old Name" }, after: { name: "New Name" }
+      )
+    end
+    log = AuditLog.last
+    assert_equal "tenant.update", log.action
+    assert_equal "Tenant", log.target_type
+    assert_equal tenant.id, log.target_id
+    assert_equal "Old Name", log.payload["before"]["name"]
+    assert_equal "New Name", log.payload["after"]["name"]
+  end
+end

--- a/test/models/campaign_instance_test.rb
+++ b/test/models/campaign_instance_test.rb
@@ -45,6 +45,7 @@ class CampaignInstanceTest < ActiveSupport::TestCase
   test "deleting the host job proposal destroys its campaign instances" do
     proposal = JobProposal.create!(
       tenant: tenants(:one),
+      location: locations(:ne_dallas),
       owner: users(:one),
       created_by_user: users(:one)
     )

--- a/test/models/job_proposal_test.rb
+++ b/test/models/job_proposal_test.rb
@@ -216,4 +216,15 @@ class JobProposalTest < ActiveSupport::TestCase
 
     assert_equal "NEW-thread", @jp.gmail_thread_id
   end
+
+  # --- PRD-01 §8.1 schema reconciliation ---------------------------------
+
+  test "location is required (PRD-01 §8.1)" do
+    jp = JobProposal.new(
+      tenant: tenants(:one),
+      owner: users(:one), created_by_user: users(:one)
+    )
+    refute jp.valid?
+    assert_includes jp.errors[:location], "must exist"
+  end
 end

--- a/test/models/job_proposal_test.rb
+++ b/test/models/job_proposal_test.rb
@@ -227,4 +227,38 @@ class JobProposalTest < ActiveSupport::TestCase
     refute jp.valid?
     assert_includes jp.errors[:location], "must exist"
   end
+
+  # --- DASH job number gating --------------------------------------------
+
+  test "dash_job_number is not required when the tenant flag is false" do
+    tenants(:one).update!(job_reference_required: false)
+    @jp.update!(status: :approved, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is not required while the proposal is drafting (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :drafting, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is not required while approving (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :approving, dash_job_number: nil)
+    assert @jp.valid?
+  end
+
+  test "dash_job_number is required to transition to approved (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.dash_job_number = nil
+    @jp.status = :approved
+    refute @jp.valid?
+    assert_includes @jp.errors[:dash_job_number], "is required before this job can be approved"
+  end
+
+  test "dash_job_number satisfies the gate when present (tenant flag on)" do
+    tenants(:one).update!(job_reference_required: true)
+    @jp.update!(status: :approved, dash_job_number: "98765")
+    assert_equal "98765", @jp.reload.dash_job_number
+  end
 end

--- a/test/models/tenant_test.rb
+++ b/test/models/tenant_test.rb
@@ -30,4 +30,26 @@ class TenantTest < ActiveSupport::TestCase
     assert_equal [], tenant.activated_job_types.to_a
     assert_equal [], tenant.activated_scenarios.to_a
   end
+
+  # --- logo resolution ---------------------------------------------------
+
+  test "logo_image_url returns the manual logo_url when no file is attached" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: "https://example.com/logo.png")
+    assert_equal "https://example.com/logo.png", tenant.logo_image_url
+  end
+
+  test "logo_image_url returns nil when neither attachment nor manual URL is set" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: nil)
+    assert_nil tenant.logo_image_url
+  end
+
+  test "logo_image_url prefers an attached blob over the manual URL" do
+    tenant = tenants(:one)
+    tenant.update!(logo_url: "https://example.com/manual.png")
+    tenant.logo.attach(io: StringIO.new("fake image"), filename: "uploaded.png", content_type: "image/png")
+    assert_match(/rails\/active_storage\/blobs/, tenant.logo_image_url)
+    refute_match(/manual.png/, tenant.logo_image_url)
+  end
 end

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -80,4 +80,32 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     assert_nil result.conversion_rate_mtd_pct
     assert_nil result.conversion_rate_ytd_pct
   end
+
+  # --- SPEC-06 v1.0 by-location breakdown -------------------------------
+
+  test "conversion_rate_by_location returns one row per location with activated/won/rate" do
+    loc_a = locations(:ne_dallas)
+    loc_b = tenants(:one).locations.create!(
+      display_name: "South Dallas", address_line_1: "5 Side", city: "Dallas",
+      state: "TX", postal_code: "75002", phone_number: "(214) 555-0202", is_active: true
+    )
+    jp_a = job_proposals(:in_users_org)
+    jp_a.update!(location: loc_a, pipeline_stage: :won)
+    CampaignInstance.create!(host: jp_a, campaign: campaigns(:approved_campaign), status: :active)
+
+    jp_b = job_proposals(:same_tenant_other_org)
+    jp_b.update!(location: loc_b, pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: jp_b, campaign: campaigns(:approved_campaign), status: :active)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    rows = result.conversion_rate_by_location
+    by_name = rows.index_by { |r| r[:location_display_name] }
+    assert_equal 100, by_name["NE Dallas"][:conversion_rate_pct]
+    assert_equal 0,   by_name["South Dallas"][:conversion_rate_pct]
+  end
+
+  test "conversion_rate_by_location is empty when no proposals have a location" do
+    result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
+    assert_equal [], result.conversion_rate_by_location
+  end
 end

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -39,4 +39,45 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
     assert_nil result.conversion_rate_pct
   end
+
+  # --- SPEC-05 v1.0 MTD/YTD --------------------------------------------
+
+  test "conversion_rate_mtd_pct is the won rate among activations created this month" do
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: :won, closed_at: Time.current.beginning_of_month + 1.hour, proposal_value: 5_000)
+    CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_month + 30.minutes)
+
+    other = job_proposals(:same_tenant_other_org)
+    other.update!(pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: other, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_month + 1.hour)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    # 1 won out of 2 activated this month → 50%
+    assert_equal 50, result.conversion_rate_mtd_pct
+  end
+
+  test "conversion_rate_ytd_pct counts only this year's activations and wins" do
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: :won, closed_at: Time.current.beginning_of_year + 1.day, proposal_value: 5_000)
+    CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: Time.current.beginning_of_year + 1.hour)
+
+    # An activation from last year — should NOT count toward YTD
+    last_year_jp = job_proposals(:same_tenant_other_org)
+    last_year_jp.update!(pipeline_stage: :in_campaign)
+    CampaignInstance.create!(host: last_year_jp, campaign: campaigns(:approved_campaign), status: :active,
+                             created_at: 14.months.ago)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    # 1 won out of 1 activated YTD → 100%
+    assert_equal 100, result.conversion_rate_ytd_pct
+  end
+
+  test "conversion_rate_mtd_pct and ytd are nil when nothing has been activated" do
+    result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
+    assert_nil result.conversion_rate_mtd_pct
+    assert_nil result.conversion_rate_ytd_pct
+  end
 end

--- a/test/services/job_proposal_processor_test.rb
+++ b/test/services/job_proposal_processor_test.rb
@@ -4,7 +4,7 @@ class JobProposalProcessorTest < ActiveSupport::TestCase
   setup do
     tenant = tenants(:one)
     @proposal = JobProposal.create!(
-      tenant: tenant,
+      tenant: tenant, location: locations(:ne_dallas),
       owner: users(:one), created_by_user: users(:one)
     )
     att = @proposal.attachments.build(uploaded_by_user: users(:one))

--- a/test/services/mail_generator_test.rb
+++ b/test/services/mail_generator_test.rb
@@ -154,21 +154,11 @@ class MailGeneratorTest < ActiveSupport::TestCase
     assert_equal "Cell:", body_without_signature(out)
   end
 
-  test "missing location yields empty location-derived fields" do
-    job_no_loc = JobProposal.create!(
-      tenant: @tenant,
-      owner: @originator,
-      created_by_user: @originator,
-      customer_first_name: "Bob",
-      customer_last_name: "Smith",
-      proposal_value: 5000
-    )
-    out = MailGenerator.render(
-      campaign_step: step(subject: "X", body: "Loc: {location_name}|{state}|{company_phone}"),
-      job_proposal: job_no_loc
-    )
-    assert_equal "Loc: ||", body_without_signature(out)
-  end
+  # The "missing location yields empty location-derived fields" test was
+  # removed: job_proposals.location_id is NOT NULL post PRD-01 §8.1
+  # reconciliation, so the case can't occur at the DB level. Optional
+  # fields within a Location (e.g. address_line_2) are still tested
+  # implicitly in the address-rendering tests above.
 
   test "unknown placeholder raises UnresolvedMergeFieldError" do
     err = assert_raises(MailGenerator::UnresolvedMergeFieldError) do
@@ -290,8 +280,13 @@ class MailGeneratorTest < ActiveSupport::TestCase
   end
 
   test "signature is omitted entirely when no pieces are available" do
+    # Build a tenant with no name fallback (name is required so we use a
+    # placeholder) and strip every signature-bearing field on the originator.
     @originator.update!(first_name: nil, last_name: nil, phone_number: nil)
-    @job.update!(location: nil)
+    # location is NOT NULL on job_proposals post PRD-01 §8.1, so we can't
+    # null it out; stub the proposal's location method to nil for this test
+    # to exercise the "no signature pieces" branch.
+    def @job.location; nil; end
 
     sig_line = "-- "
     out = MailGenerator.render(

--- a/test/services/mail_generator_test.rb
+++ b/test/services/mail_generator_test.rb
@@ -135,7 +135,17 @@ class MailGeneratorTest < ActiveSupport::TestCase
     assert_equal "10280 Miller Rd, Dallas, TX, 75238\nTexas\n(214) 343-3973", body_without_signature(out)
   end
 
-  test "company_name renders the tenant name" do
+  test "company_name renders tenant.company_name when set" do
+    @tenant.update!(company_name: "Servpro of NE Dallas")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "X", body: "From {company_name}"),
+      job_proposal: @job
+    )
+    assert_equal "From Servpro of NE Dallas", body_without_signature(out)
+  end
+
+  test "company_name falls back to tenant.name when company_name is blank" do
+    @tenant.update!(company_name: nil)
     out = MailGenerator.render(
       campaign_step: step(subject: "X", body: "From {company_name}"),
       job_proposal: @job

--- a/test/services/mail_generator_test.rb
+++ b/test/services/mail_generator_test.rb
@@ -245,6 +245,35 @@ class MailGeneratorTest < ActiveSupport::TestCase
 
   # --- signature ---
 
+  # --- DASH subject prefix -----------------------------------------------
+
+  test "subject is prefixed with [DASH-NNN] when the proposal has a dash_job_number" do
+    @job.update!(dash_job_number: "12345")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "Following up on {property_address_short}", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "[DASH-12345] Following up on 1247 Oak Ridge Drive", out.subject
+  end
+
+  test "subject is unchanged when dash_job_number is blank" do
+    @job.update!(dash_job_number: nil)
+    out = MailGenerator.render(
+      campaign_step: step(subject: "Hello", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "Hello", out.subject
+  end
+
+  test "DASH prefix is idempotent — subject already prefixed isn't doubled" do
+    @job.update!(dash_job_number: "12345")
+    out = MailGenerator.render(
+      campaign_step: step(subject: "[DASH-12345] Already prefixed", body: "Body."),
+      job_proposal: @job
+    )
+    assert_equal "[DASH-12345] Already prefixed", out.subject
+  end
+
   test "render appends the signature with originator + company info" do
     out = MailGenerator.render(
       campaign_step: step(subject: "X", body: "Body text."),


### PR DESCRIPTION
## What this is

A consolidated PR landing the v0.1 - Happy Path stack (PRs #156, #157, #160, #161, #162, #163) onto main in one go. The original stacked PRs merged into their intermediate stack branches rather than into main, so the work was sitting on `pr/analytics-branch-comparison` without ever bridging to `main`. This PR brings the six commits across.

Each commit was reviewed individually under its original PR. The diffs and commit history are unchanged.

## Commits, in order (closes the same issues the originals did)

1. `30bb274` — reconcile job_proposals schema to PRD-01 §8.1 (closes #42)
2. `e66a5b7` — DASH job number end-to-end (closes #151)
3. `23cfe1a` — account fields, tenant edit, and audit logging (closes #106)
4. `e6c9c52` — logo upload pipeline (closes #107)
5. `2ed1b81` — analytics: MTD/YTD on Conversion Rate hero tile (closes #87)
6. `9e385b6` — analytics: per-location Conversion Rate breakdown (closes #91)

## Test plan

- [ ] `rails test` — passing on the tip branch (678 runs locally).
- [ ] After merge: `rails db:migrate` to apply the four new migrations (`20260508235849`, `20260509000505`, `20260509001343`, plus the location_id NOT NULL on locations from earlier).

## Merge style

**Merge commit** (or rebase-and-merge) preserves the per-commit review lineage. **Squash-merge** would collapse the six commits into one — fine if you don't need the per-commit history on main; loses the granular blame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)