### PR TITLE
Admin user editing, invite-modal parity, role-gated invitations

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -8,16 +8,34 @@ class Admin::InvitationsController < Admin::BaseController
         alert: "Can't send invitations yet: #{blockers.join(' ')}" and return
     end
 
+    is_account_admin = ActiveModel::Type::Boolean.new.cast(params.dig(:invitation, :is_account_admin))
+    location_id = params.dig(:invitation, :location_id).presence
+
+    if !is_account_admin && location_id.blank?
+      redirect_to admin_tenant_path(@tenant),
+        alert: "Pick a location, or check Is Account Admin." and return
+    end
+
+    location = nil
+    if location_id.present?
+      location = @tenant.locations.find_by(id: location_id)
+      if location.nil?
+        redirect_to admin_tenant_path(@tenant),
+          alert: "That location isn't part of this tenant." and return
+      end
+    end
+
     email = params.dig(:invitation, :email).to_s.strip
     existing = email.blank? ? nil : User.find_by(email: email.downcase)
     if existing
-      result = handle_existing_user_invite(existing, tenant: @tenant)
+      result = handle_existing_user_invite(existing, tenant: @tenant, location: location)
       redirect_to admin_tenant_path(@tenant), **result and return
     end
 
     invitation = @tenant.invitations.build(
       invited_by_user: current_user,
       email: email,
+      location: location,
       first_name: params.dig(:invitation, :first_name).to_s.strip.presence,
       last_name: params.dig(:invitation, :last_name).to_s.strip.presence,
       phone_number: params.dig(:invitation, :phone_number).to_s.strip.presence,
@@ -68,7 +86,7 @@ class Admin::InvitationsController < Admin::BaseController
   # Same shape as InvitationsController#handle_existing_user_invite —
   # see the comment there. Inlined rather than extracted because the
   # tenant resolution (current_user.tenant vs @tenant) differs.
-  def handle_existing_user_invite(user, tenant:)
+  def handle_existing_user_invite(user, tenant:, location: nil)
     if user.is_admin
       return { alert: "#{user.email} is a system admin — admins aren't added through tenant invites." }
     end
@@ -79,7 +97,10 @@ class Admin::InvitationsController < Admin::BaseController
       return { alert: "#{user.email} is already in #{tenant.name}." }
     end
 
-    user.update!(tenant: tenant)
+    User.transaction do
+      user.update!(tenant: tenant)
+      user.update!(location: location) if location && user.location_id.nil?
+    end
     { notice: "Added #{user.email} to #{tenant.name}." }
   end
 

--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -12,6 +12,7 @@ class Admin::TenantsController < Admin::BaseController
     @pending_invitations = @tenant.invitations.where(accepted_at: nil).order(created_at: :desc)
     @users = @tenant.users.includes(:location).order(:email)
     @locations = @tenant.locations.order(:display_name)
+    @invite_locations = @tenant.locations.active.order(:display_name)
   end
 
   def new

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -95,6 +95,9 @@ class InvitationsController < ApplicationController
     if invitation.nil?
       redirect_to users_path, alert: "Invitation not found." and return
     end
+    unless current_user.can_invite_into_tenant?
+      redirect_to users_path, alert: "Only account admins can revoke invitations." and return
+    end
     if invitation.accepted?
       redirect_to users_path, alert: "That invitation has already been accepted and can't be revoked." and return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,21 @@
 class UsersController < ApplicationController
+  EDITABLE_PARAMS = %i[first_name last_name title phone_number location_id].freeze
+
+  before_action :load_user, only: [:edit, :update]
+  before_action :require_admin_access, only: [:edit, :update]
+
   def index
     @tenant = current_user.tenant
     if @tenant
       @users = @tenant.users.includes(:email_delegations, :location).order(:email)
-      @pending_invitations = @tenant.invitations.where(accepted_at: nil).order(created_at: :desc)
+      # Pending invitations only flow to the view for users who can act on
+      # them (account admins / app admins). Regular tenant users get an
+      # empty relation so the data never crosses the controller boundary.
+      @pending_invitations = if current_user.can_invite_into_tenant?
+        @tenant.invitations.where(accepted_at: nil).order(created_at: :desc)
+      else
+        Invitation.none
+      end
       @invite_locations = @tenant.locations.active.order(:display_name)
     else
       @users = User.none
@@ -11,5 +23,56 @@ class UsersController < ApplicationController
       @invite_locations = Location.none
     end
     @invitation = Invitation.new
+  end
+
+  def edit
+    @location_options = current_user.tenant.locations.active.order(:display_name)
+  end
+
+  def update
+    before = audit_snapshot(@user)
+    if @user.update(user_params)
+      AuditLogger.write(
+        tenant: current_user.tenant, actor: current_user,
+        action: "user.update", target: @user,
+        before: before, after: audit_snapshot(@user)
+      )
+      redirect_to users_path, notice: "Updated #{@user.display_name}."
+    else
+      @location_options = current_user.tenant.locations.active.order(:display_name)
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  # Operator path: only tenant admins / app admins can edit; only members
+  # of the current user's tenant. SMAI-staff cross-tenant edits live on
+  # the admin namespace separately.
+  def load_user
+    @user = current_user.tenant&.users&.find_by(id: params[:id])
+    if @user.nil?
+      redirect_to users_path, alert: "User not found in your team." and return
+    end
+  end
+
+  def require_admin_access
+    return if current_user.can_invite_into_tenant?
+    redirect_to users_path, alert: "Only account admins can edit teammates."
+  end
+
+  def user_params
+    attrs = params.require(:user).permit(*EDITABLE_PARAMS)
+    # Defense in depth: even when the form posts a location_id, drop it
+    # if the picked location doesn't belong to current_user's tenant.
+    if attrs[:location_id].present? &&
+       !current_user.tenant.locations.exists?(id: attrs[:location_id])
+      attrs = attrs.except(:location_id)
+    end
+    attrs
+  end
+
+  def audit_snapshot(user)
+    user.slice(:first_name, :last_name, :title, :phone_number, :location_id)
   end
 end

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -144,7 +144,15 @@
   <div class="col-lg-5">
     <div class="card shadow-sm mb-3">
       <div class="card-body p-4">
-        <h2 class="h5 mb-3">Invite a user</h2>
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h2 class="h5 mb-0">Invite a user</h2>
+          <% if Invitation.can_send? %>
+            <button type="button" class="btn btn-primary btn-sm"
+                    data-bs-toggle="modal" data-bs-target="#adminInviteUserModal">
+              Invite user
+            </button>
+          <% end %>
+        </div>
         <% blockers = Invitation.send_blockers %>
         <% if blockers.any? %>
           <div class="alert alert-warning mb-0">
@@ -156,12 +164,9 @@
             </ul>
           </div>
         <% else %>
-          <%= form_with model: @invitation, url: admin_tenant_invitations_path(@tenant), local: true do |f| %>
-            <div class="input-group">
-              <%= f.email_field :email, class: "form-control", placeholder: "name@example.com", required: true %>
-              <%= f.submit "Send invite", class: "btn btn-primary" %>
-            </div>
-          <% end %>
+          <p class="text-muted small mb-0">
+            Click <em>Invite user</em> to capture the invitee's full profile (name, title, phone, location).
+          </p>
         <% end %>
       </div>
     </div>
@@ -191,3 +196,91 @@
     </div>
   </div>
 </div>
+
+<% if Invitation.can_send? %>
+  <div class="modal fade" id="adminInviteUserModal" tabindex="-1" aria-labelledby="adminInviteUserModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <%= form_with model: @invitation, url: admin_tenant_invitations_path(@tenant), local: true do |f| %>
+          <div class="modal-header">
+            <h5 class="modal-title" id="adminInviteUserModalLabel">Invite a user to <%= @tenant.name %></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-2 mb-3">
+              <div class="col-md-6">
+                <%= f.label :first_name, "First name", class: "form-label" %>
+                <%= f.text_field :first_name, class: "form-control", autocomplete: "off" %>
+              </div>
+              <div class="col-md-6">
+                <%= f.label :last_name, "Last name", class: "form-label" %>
+                <%= f.text_field :last_name, class: "form-control", autocomplete: "off" %>
+              </div>
+            </div>
+            <div class="mb-3">
+              <%= f.label :email, "Email address", class: "form-label" %>
+              <%= f.email_field :email, class: "form-control", placeholder: "name@example.com", required: true %>
+            </div>
+            <div class="row g-2 mb-3">
+              <div class="col-md-6">
+                <%= f.label :title, "Title", class: "form-label" %>
+                <%= f.text_field :title, class: "form-control", placeholder: "e.g. Estimator", autocomplete: "off" %>
+              </div>
+              <div class="col-md-6">
+                <%= f.label :phone_number, "Phone number", class: "form-label" %>
+                <%= f.telephone_field :phone_number, class: "form-control", placeholder: "(214) 555-0100", autocomplete: "off" %>
+              </div>
+            </div>
+            <div class="form-check mb-3">
+              <%= f.check_box :is_account_admin, class: "form-check-input", id: "admin-invite-is-account-admin", data: { admin_invite_target: "checkbox" } %>
+              <%= f.label :is_account_admin, "Is Account Admin", class: "form-check-label", for: "admin-invite-is-account-admin" %>
+              <div class="form-text">Account admins aren't tied to a single location.</div>
+            </div>
+            <div class="mb-0" id="admin-invite-location-field" data-admin-invite-target="locationField">
+              <%= f.label :location_id, "Location", class: "form-label" %>
+              <%= f.select :location_id,
+                    @invite_locations.map { |loc| [loc.display_name, loc.id] },
+                    { include_blank: "Select a location" },
+                    { class: "form-select", id: "admin-invite-location-select", required: true, data: { admin_invite_target: "select" } } %>
+              <% if @invite_locations.empty? %>
+                <div class="form-text text-warning">No active locations are configured for this tenant yet.</div>
+              <% end %>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <%= f.submit "Send invite", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      function init() {
+        var checkbox = document.getElementById("admin-invite-is-account-admin");
+        var field = document.getElementById("admin-invite-location-field");
+        var select = document.getElementById("admin-invite-location-select");
+        if (!checkbox || !field || !select) return;
+        function sync() {
+          if (checkbox.checked) {
+            field.style.display = "none";
+            select.required = false;
+            select.value = "";
+          } else {
+            field.style.display = "";
+            select.required = true;
+          }
+        }
+        checkbox.addEventListener("change", sync);
+        sync();
+      }
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+      } else {
+        init();
+      }
+    })();
+  </script>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,63 @@
+<% content_for :title, "Edit #{@user.display_name}" %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">Edit teammate</h1>
+  <%= link_to "Back to Team", users_path, class: "btn btn-sm btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body p-4">
+    <%= form_with model: @user, url: user_path(@user), method: :patch, local: true do |f| %>
+      <% if @user.errors.any? %>
+        <div class="alert alert-danger">
+          <strong>Please fix the following:</strong>
+          <ul class="mb-0">
+            <% @user.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <dl class="row mb-3">
+        <dt class="col-sm-3">Email</dt>
+        <dd class="col-sm-9"><%= @user.email %></dd>
+      </dl>
+
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <%= f.label :first_name, class: "form-label" %>
+          <%= f.text_field :first_name, class: "form-control" %>
+        </div>
+        <div class="col-md-6">
+          <%= f.label :last_name, class: "form-label" %>
+          <%= f.text_field :last_name, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :title, class: "form-label" %>
+        <%= f.text_field :title, class: "form-control", placeholder: "e.g. Estimator" %>
+        <div class="form-text">Shown in the email signature.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.telephone_field :phone_number, class: "form-control", placeholder: "(214) 555-0100" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :location_id, "Location", class: "form-label" %>
+        <%= f.collection_select :location_id, @location_options, :id, :display_name,
+              { include_blank: "— None (account admin) —" },
+              class: "form-select" %>
+        <div class="form-text">Originators are scoped to one location. Leave blank to make this user a tenant admin.</div>
+      </div>
+
+      <div class="d-flex gap-2">
+        <%= f.submit "Save", class: "btn btn-primary" %>
+        <%= link_to "Cancel", users_path, class: "btn btn-outline-secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,6 +29,9 @@
               <th>Location</th>
               <th>Gmail</th>
               <th class="text-end">Status</th>
+              <% if current_user.can_invite_into_tenant? %>
+                <th class="text-end" style="width: 1%;"></th>
+              <% end %>
             </tr>
           </thead>
           <tbody>
@@ -75,6 +78,11 @@
                     <span class="badge text-bg-success">Active</span>
                   <% end %>
                 </td>
+                <% if current_user.can_invite_into_tenant? %>
+                  <td class="text-end">
+                    <%= link_to "Edit", edit_user_path(user), class: "btn btn-sm btn-outline-primary" %>
+                  </td>
+                <% end %>
               </tr>
             <% end %>
           </tbody>
@@ -85,39 +93,41 @@
     </div>
   </div>
 
-  <div class="card shadow-sm">
-    <div class="card-header">
-      <h3 class="h6 mb-0">Pending invitations</h3>
-    </div>
-    <div class="card-body p-0">
-      <% if @pending_invitations.any? %>
-        <ul class="list-group list-group-flush mb-0">
-          <% @pending_invitations.each do |inv| %>
-            <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div>
-                <div class="fw-semibold"><%= inv.email %></div>
-                <div class="small text-muted">
-                  Invited by <%= inv.invited_by_user.display_name %> ·
-                  sent <%= time_ago_in_words(inv.created_at) %> ago ·
-                  <% if inv.expired? %>
-                    <span class="text-danger">expired</span>
-                  <% else %>
-                    expires <%= time_ago_in_words(inv.expires_at) %> from now
-                  <% end %>
+  <% if current_user.can_invite_into_tenant? %>
+    <div class="card shadow-sm">
+      <div class="card-header">
+        <h3 class="h6 mb-0">Pending invitations</h3>
+      </div>
+      <div class="card-body p-0">
+        <% if @pending_invitations.any? %>
+          <ul class="list-group list-group-flush mb-0">
+            <% @pending_invitations.each do |inv| %>
+              <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <div class="fw-semibold"><%= inv.email %></div>
+                  <div class="small text-muted">
+                    Invited by <%= inv.invited_by_user.display_name %> ·
+                    sent <%= time_ago_in_words(inv.created_at) %> ago ·
+                    <% if inv.expired? %>
+                      <span class="text-danger">expired</span>
+                    <% else %>
+                      expires <%= time_ago_in_words(inv.expires_at) %> from now
+                    <% end %>
+                  </div>
                 </div>
-              </div>
-              <%= button_to "Revoke", invitation_path(inv),
-                    method: :delete,
-                    class: "btn btn-sm btn-outline-danger",
-                    form: { class: "m-0", data: { turbo_confirm: "Revoke the pending invitation for #{inv.email}?" } } %>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <div class="p-3 text-center text-muted small">No pending invitations.</div>
-      <% end %>
+                <%= button_to "Revoke", invitation_path(inv),
+                      method: :delete,
+                      class: "btn btn-sm btn-outline-danger",
+                      form: { class: "m-0", data: { turbo_confirm: "Revoke the pending invitation for #{inv.email}?" } } %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <div class="p-3 text-center text-muted small">No pending invitations.</div>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <% if current_user.can_invite_into_tenant? %>
   <div class="modal fade" id="inviteUserModal" tabindex="-1" aria-labelledby="inviteUserModalLabel" aria-hidden="true">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
   resources :invitations, only: [:show, :create, :destroy]
-  resources :users, only: [:index]
+  resources :users, only: [:index, :edit, :update]
   get "profile" => "profiles#show", as: :profile
   get "profile/edit" => "profiles#edit", as: :edit_profile
   patch "profile" => "profiles#update"

--- a/test/controllers/admin/invitations_controller_test.rb
+++ b/test/controllers/admin/invitations_controller_test.rb
@@ -20,7 +20,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
   test "without an application mailbox the invitation is refused with a clear blocker message" do
     sign_in @admin
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com", is_account_admin: "1" } }
     end
     assert_empty GmailSender.deliveries
     assert_redirected_to admin_tenant_path(@tenant)
@@ -35,7 +35,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     prior = ENV.delete("APP_HOST")
     begin
       assert_no_difference "Invitation.count" do
-        post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com" } }
+        post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com", is_account_admin: "1" } }
       end
       assert_match(/APP_HOST is not set/i, flash[:alert].to_s)
     ensure
@@ -49,7 +49,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @admin
 
     assert_difference "Invitation.count", 1 do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "lead@example.com", is_account_admin: "1" } }
     end
 
     assert_equal 1, GmailSender.deliveries.size
@@ -61,11 +61,58 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     assert_match invitation.token, delivery[:body]
   end
 
+  test "admin: invite is rejected when neither admin nor location is provided" do
+    ApplicationMailbox.create!(provider: "google_oauth2", email: "noreply@app.example.com", access_token: "tok", expires_at: 1.hour.from_now)
+    sign_in @admin
+    assert_no_difference "Invitation.count" do
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "needs-loc@example.com" } }
+    end
+    assert_redirected_to admin_tenant_path(@tenant)
+    assert_match(/Pick a location, or check Is Account Admin/i, flash[:alert].to_s)
+  end
+
+  test "admin: invite persists location_id when one is chosen" do
+    ApplicationMailbox.create!(provider: "google_oauth2", email: "noreply@app.example.com", access_token: "tok", expires_at: 1.hour.from_now)
+    location = @tenant.locations.create!(
+      display_name: "Dallas", address_line_1: "1 Main", city: "Dallas",
+      state: "TX", postal_code: "75001", phone_number: "(214) 555-0101", is_active: true
+    )
+    sign_in @admin
+
+    assert_difference "Invitation.count", 1 do
+      post admin_tenant_invitations_url(@tenant), params: { invitation: {
+        email: "loc-admin-invite@example.com", location_id: location.id,
+        first_name: "Pat", last_name: "Quinn", title: "Estimator", phone_number: "(214) 555-1212"
+      } }
+    end
+    inv = Invitation.where(email: "loc-admin-invite@example.com").last
+    assert_equal location, inv.location
+    assert_equal "Pat", inv.first_name
+    assert_equal "Estimator", inv.title
+  end
+
+  test "admin: invite rejects a location from a different tenant" do
+    ApplicationMailbox.create!(provider: "google_oauth2", email: "noreply@app.example.com", access_token: "tok", expires_at: 1.hour.from_now)
+    other_tenant = Tenant.create!(name: "OtherCo3")
+    foreign_location = other_tenant.locations.create!(
+      display_name: "Foreign", address_line_1: "9 Foreign", city: "Reno",
+      state: "NV", postal_code: "89501", phone_number: "(775) 555-0303", is_active: true
+    )
+    sign_in @admin
+
+    assert_no_difference "Invitation.count" do
+      post admin_tenant_invitations_url(@tenant), params: { invitation: {
+        email: "leak-admin@example.com", location_id: foreign_location.id
+      } }
+    end
+    assert_match(/isn't part of this tenant/i, flash[:alert].to_s)
+  end
+
   test "creating an invitation with a blank email is rejected" do
     ApplicationMailbox.create!(provider: "google_oauth2", email: "noreply@app.example.com", access_token: "tok")
     sign_in @admin
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "", is_account_admin: "1" } }
     end
     assert_redirected_to admin_tenant_path(@tenant)
     assert_match(/email can/i, flash[:alert].to_s)
@@ -80,7 +127,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
 
     GmailSender.reset_deliveries!
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "tenantless2@example.com" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "tenantless2@example.com", is_account_admin: "1" } }
     end
     assert_empty GmailSender.deliveries
     assert_equal @tenant, existing.reload.tenant
@@ -93,7 +140,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @admin
 
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "alreadyhere2@example.com" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "alreadyhere2@example.com", is_account_admin: "1" } }
     end
     assert_match(/already in #{Regexp.escape(@tenant.name)}/i, flash[:alert].to_s)
   end
@@ -105,7 +152,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @admin
 
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "elsewhere2@example.com" } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: "elsewhere2@example.com", is_account_admin: "1" } }
     end
     assert_match(/another tenant/i, flash[:alert].to_s)
   end
@@ -114,7 +161,7 @@ class Admin::InvitationsControllerTest < ActionDispatch::IntegrationTest
     ApplicationMailbox.create!(provider: "google_oauth2", email: "noreply@app.example.com", access_token: "tok")
     sign_in @admin
     assert_no_difference "Invitation.count" do
-      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: @admin.email } }
+      post admin_tenant_invitations_url(@tenant), params: { invitation: { email: @admin.email, is_account_admin: "1" } }
     end
     assert_match(/system admin/i, flash[:alert].to_s)
   end

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -228,6 +228,21 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/not found/i, flash[:alert].to_s)
   end
 
+  test "regular tenant user can't revoke an invitation in their tenant" do
+    location = @tenant.locations.create!(
+      display_name: "Main", address_line_1: "1 Main", city: "Dallas",
+      state: "TX", postal_code: "75001", phone_number: "(214) 555-0101", is_active: true
+    )
+    regular = User.create!(email: "regular-revoke@example.com", password: "Password1", is_pending: false, tenant: @tenant, location: location)
+    sign_in regular
+
+    assert_no_difference "Invitation.count" do
+      delete invitation_path(@invitation)
+    end
+    assert_redirected_to users_path
+    assert_match(/Only account admins/i, flash[:alert].to_s)
+  end
+
   test "destroy refuses to revoke an already-accepted invitation" do
     @invitation.update!(accepted_at: Time.current)
     signed_in_inviter(email: "revoker2@example.com")

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -104,6 +104,109 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match "Originator", response.body
   end
 
+  # --- edit / update ------------------------------------------------------
+
+  test "edit redirects to sign-in when not signed in" do
+    teammate = User.create!(email: "victim@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+    get edit_user_url(teammate)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "tenant admin can open the edit form for a teammate" do
+    teammate = User.create!(email: "teammate@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+    sign_in @user # tenant admin (no location)
+    get edit_user_url(teammate)
+    assert_response :success
+    assert_select "form input[name='user[first_name]']"
+    assert_select "form input[name='user[last_name]']"
+    assert_select "form input[name='user[title]']"
+    assert_select "form input[name='user[phone_number]']"
+    assert_select "form select[name='user[location_id]']"
+  end
+
+  test "tenant admin can update a teammate and writes an audit log row" do
+    location = @tenant.locations.create!(
+      display_name: "Main", address_line_1: "1 Main", city: "Dallas",
+      state: "TX", postal_code: "75001", phone_number: "(214) 555-0101", is_active: true
+    )
+    teammate = User.create!(email: "teammate-up@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+    sign_in @user
+
+    assert_difference "AuditLog.count", 1 do
+      patch user_url(teammate), params: { user: {
+        first_name: "Pat", last_name: "Quinn",
+        title: "Estimator", phone_number: "(214) 555-1212",
+        location_id: location.id
+      } }
+    end
+    assert_redirected_to users_path
+    teammate.reload
+    assert_equal "Pat", teammate.first_name
+    assert_equal "Quinn", teammate.last_name
+    assert_equal "Estimator", teammate.title
+    assert_equal "(214) 555-1212", teammate.phone_number
+    assert_equal location, teammate.location
+  end
+
+  test "regular tenant user can't reach edit or update" do
+    @user.update!(location: locations(:ne_dallas))   # make @user regular
+    teammate = User.create!(email: "teammate-blocked@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+    sign_in @user
+
+    get edit_user_url(teammate)
+    assert_redirected_to users_path
+    assert_match(/Only account admins/i, flash[:alert].to_s)
+
+    patch user_url(teammate), params: { user: { first_name: "Hax" } }
+    assert_redirected_to users_path
+    assert_nil teammate.reload.first_name
+  end
+
+  test "edit can't reach a user from another tenant" do
+    other_tenant = Tenant.create!(name: "OtherCo")
+    outsider = User.create!(email: "outsider-edit@example.com", password: "Password1", is_pending: false, tenant: other_tenant)
+    sign_in @user
+
+    get edit_user_url(outsider)
+    assert_redirected_to users_path
+    assert_match(/not found in your team/i, flash[:alert].to_s)
+  end
+
+  test "update drops a tampered location_id from another tenant" do
+    other_tenant = Tenant.create!(name: "OtherCo2")
+    foreign_location = other_tenant.locations.create!(
+      display_name: "Foreign", address_line_1: "9 Foreign", city: "Reno",
+      state: "NV", postal_code: "89501", phone_number: "(775) 555-0303", is_active: true
+    )
+    teammate = User.create!(email: "teammate-cross@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+    sign_in @user
+
+    patch user_url(teammate), params: { user: { first_name: "X", location_id: foreign_location.id } }
+    assert_redirected_to users_path
+    teammate.reload
+    assert_equal "X", teammate.first_name
+    assert_nil teammate.location_id, "cross-tenant location_id must be dropped"
+  end
+
+  test "regular tenant user does not see the Pending invitations card" do
+    Invitation.create!(tenant: @tenant, invited_by_user: @user, email: "pending-hidden@example.com")
+    @user.update!(location: locations(:ne_dallas)) # regular user
+    sign_in @user
+    get users_url
+    assert_response :success
+    assert_no_match(/Pending invitations/i, response.body)
+    assert_no_match("pending-hidden@example.com", response.body)
+  end
+
+  test "tenant admin still sees the Pending invitations card" do
+    Invitation.create!(tenant: @tenant, invited_by_user: @user, email: "pending-shown@example.com")
+    sign_in @user # tenant admin
+    get users_url
+    assert_response :success
+    assert_match(/Pending invitations/i, response.body)
+    assert_match("pending-shown@example.com", response.body)
+  end
+
   test "regular tenant user (with a location) does not see the Invite button or modal" do
     location = @tenant.locations.create!(
       display_name: "Main", address_line_1: "1 Main", city: "Dallas",


### PR DESCRIPTION
## Summary

Three related team-management changes:

1. **Edit a teammate (operator-facing).** `/users/:id/edit` lets account admins / app admins change first name, last name, title, phone number, and location for any user in their tenant. Edit link in the Team table only renders for admins. Update writes an AuditLog row. Cross-tenant lookups and tampered cross-tenant `location_id` are both rejected server-side.

2. **SMAI admin tenant invite page now uses the full modal.** Replaces the email-only inline form with the same modal the operator-facing `/users` page uses — first/last name, title, phone, email, Is Account Admin checkbox, location select. `Admin::InvitationsController#create` enforces the "admin OR location" gate and rejects locations from other tenants.

3. **Pending invitations are role-gated server-side.**
   - Admins always see the section, even when empty
   - Non-admins never see it
   - Two-layer gate: controller returns `Invitation.none` for non-admins; view wraps the section in `current_user.can_invite_into_tenant?`
   - `InvitationsController#destroy` rejects non-admin revokes with an alert

## Test plan

- [x] `rails test` — 690 runs, 0 failures.
- [ ] Smoke as a tenant admin: visit /users, click Edit on a teammate, change title + location, save. Confirm flash + AuditLog row.
- [ ] Smoke as a regular user: visit /users — no Edit links, no Pending invitations card, no Invite button.
- [ ] Smoke as an SMAI admin: visit /admin/tenants/:id, click "Invite user", confirm full modal with all fields including the location select gated by Is Account Admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)