### PR TITLE
Hotfix: 3-pass location_id backfill for the Heroku release migration

### DIFF
--- a/db/migrate/20260508235849_reconcile_job_proposal_schema.rb
+++ b/db/migrate/20260508235849_reconcile_job_proposal_schema.rb
@@ -4,8 +4,9 @@ class ReconcileJobProposalSchema < ActiveRecord::Migration[8.1]
     # String for now — there's no template_versions table yet (separate PR).
     add_column :campaigns, :template_version_id, :string
 
-    # Backfill nil location_id with the proposal's tenant's first active
-    # location. Then lock NOT NULL.
+    # Backfill nil location_id in three passes, then lock NOT NULL.
+    #
+    # Pass 1: prefer the tenant's first ACTIVE location.
     execute <<~SQL
       UPDATE job_proposals AS jp
          SET location_id = sub.id
@@ -16,6 +17,48 @@ class ReconcileJobProposalSchema < ActiveRecord::Migration[8.1]
            ORDER BY tenant_id, id
         ) AS sub
        WHERE jp.tenant_id = sub.tenant_id
+         AND jp.location_id IS NULL
+    SQL
+
+    # Pass 2: tenants without any active location fall back to any
+    # location they own (active or not). This handles accounts that
+    # have created locations but never flipped them to is_active.
+    execute <<~SQL
+      UPDATE job_proposals AS jp
+         SET location_id = sub.id
+        FROM (
+          SELECT DISTINCT ON (tenant_id) id, tenant_id
+            FROM locations
+           ORDER BY tenant_id, id
+        ) AS sub
+       WHERE jp.tenant_id = sub.tenant_id
+         AND jp.location_id IS NULL
+    SQL
+
+    # Pass 3: tenants that still have nil-location proposals own no
+    # locations at all. Synthesize a placeholder so the migration can
+    # complete cleanly. Operators see it in their tenant locations
+    # list (with an obvious "placeholder" label) and can edit/replace
+    # via the admin tenant page. is_active defaults to false so the
+    # placeholder doesn't immediately become a default for anything else.
+    placeholder_label = "(Default — placeholder, please update)"
+    execute <<~SQL
+      WITH new_locations AS (
+        INSERT INTO locations
+          (tenant_id, display_name, address_line_1, city, state,
+           postal_code, phone_number, is_active, created_at, updated_at)
+        SELECT DISTINCT jp.tenant_id, #{connection.quote(placeholder_label)},
+               'Address pending', 'Pending', 'TX',
+               '00000', '(000) 000-0000', false,
+               NOW(), NOW()
+          FROM job_proposals jp
+         WHERE jp.location_id IS NULL
+        RETURNING id, tenant_id
+      )
+      UPDATE job_proposals AS jp
+         SET location_id = nl.id
+        FROM new_locations nl
+       WHERE jp.tenant_id = nl.tenant_id
          AND jp.location_id IS NULL
     SQL
 


### PR DESCRIPTION
## What broke

Heroku release ran the \`20260508235849_reconcile_job_proposal_schema\` migration. After the active-only backfill pass, **9 proposals still had nil \`location_id\`** because their tenants either:

- have no active locations, only inactive ones, or
- have zero locations entirely.

The migration's safety \`raise\` fired and the release was rolled back.

## Fix

Three-pass backfill, then the existing NOT NULL lock:

1. Tenant's first ACTIVE location (unchanged from before).
2. **NEW** — Any location for tenants with no active one.
3. **NEW** — Synthesize a placeholder location for tenants with zero locations and assign nil-location proposals to it. The placeholder is \`is_active = false\` so it's obvious to operators in the admin tenant page; \`display_name\` is \`(Default — placeholder, please update)\`.

After all three passes there shouldn't be any nil \`location_id\` rows. The existing raise-and-stop guard stays as the last line of defense.

## Why a placeholder vs. raising

The model has \`belongs_to :location\` (no \`optional: true\`), so a nil \`location_id\` would break the app at runtime even without the NOT NULL constraint. We need every proposal to point at *something*. The placeholder lets the migration finish; the operator replaces it via the admin UI.

## Test plan

- [x] \`rails test\` — 690 runs, 0 failures (test DB loads schema.rb directly, doesn't run migrations).
- [ ] Deploy to Heroku — release should succeed. After: visit each affected tenant's admin page and replace \`(Default — placeholder…)\` locations with real ones.
- [ ] On Heroku, confirm \`SELECT COUNT(*) FROM job_proposals WHERE location_id IS NULL\` returns 0.

## Operator follow-up

After this lands, the affected tenants will have an extra "Default" location showing as inactive. SMAI staff should:
1. Visit \`/admin/tenants/:id\` for each tenant that had nil-location proposals.
2. Either edit the placeholder with real address/phone or delete it and re-assign the proposals to a real location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)