### PR TITLE
Admin user editing from /admin/tenants/:id

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,52 @@
+class Admin::UsersController < Admin::BaseController
+  EDITABLE_PARAMS = %i[first_name last_name title phone_number location_id].freeze
+
+  before_action :load_tenant
+  before_action :load_user
+
+  def edit
+    @location_options = @tenant.locations.active.order(:display_name)
+  end
+
+  def update
+    before = audit_snapshot(@user)
+    if @user.update(user_params)
+      AuditLogger.write(
+        tenant: @tenant, actor: current_user,
+        action: "user.update", target: @user,
+        before: before, after: audit_snapshot(@user)
+      )
+      redirect_to admin_tenant_path(@tenant), notice: "Updated #{@user.display_name}."
+    else
+      @location_options = @tenant.locations.active.order(:display_name)
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def load_tenant
+    @tenant = Tenant.find(params[:tenant_id])
+  end
+
+  def load_user
+    @user = @tenant.users.find_by(id: params[:id])
+    return if @user
+    redirect_to admin_tenant_path(@tenant), alert: "User not found in this tenant."
+  end
+
+  def user_params
+    attrs = params.require(:user).permit(*EDITABLE_PARAMS)
+    # Defense in depth: drop a tampered location_id that doesn't belong
+    # to the tenant being edited.
+    if attrs[:location_id].present? &&
+       !@tenant.locations.exists?(id: attrs[:location_id])
+      attrs = attrs.except(:location_id)
+    end
+    attrs
+  end
+
+  def audit_snapshot(user)
+    user.slice(:first_name, :last_name, :title, :phone_number, :location_id)
+  end
+end

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -61,6 +61,7 @@
                 <th>Email</th>
                 <th>Location</th>
                 <th class="text-end">Status</th>
+                <th class="text-end" style="width: 1%;"></th>
               </tr>
             </thead>
             <tbody>
@@ -90,6 +91,9 @@
                     <% else %>
                       <span class="badge text-bg-success">Active</span>
                     <% end %>
+                  </td>
+                  <td class="text-end">
+                    <%= link_to "Edit", edit_admin_tenant_user_path(@tenant, user), class: "btn btn-sm btn-outline-primary" %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, "Edit #{@user.display_name}" %>
+
+<%= render "shared/admin_breadcrumb", tenant: @tenant, current: :tenant %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">Edit <%= @user.display_name %></h1>
+  <%= link_to "Back to #{@tenant.name}", admin_tenant_path(@tenant), class: "btn btn-sm btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body p-4">
+    <%= form_with model: @user, url: admin_tenant_user_path(@tenant, @user), method: :patch, local: true do |f| %>
+      <% if @user.errors.any? %>
+        <div class="alert alert-danger">
+          <strong>Please fix the following:</strong>
+          <ul class="mb-0">
+            <% @user.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <dl class="row mb-3">
+        <dt class="col-sm-3">Email</dt>
+        <dd class="col-sm-9"><%= @user.email %></dd>
+
+        <dt class="col-sm-3">Tenant</dt>
+        <dd class="col-sm-9"><%= @tenant.name %></dd>
+      </dl>
+
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <%= f.label :first_name, class: "form-label" %>
+          <%= f.text_field :first_name, class: "form-control" %>
+        </div>
+        <div class="col-md-6">
+          <%= f.label :last_name, class: "form-label" %>
+          <%= f.text_field :last_name, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :title, class: "form-label" %>
+        <%= f.text_field :title, class: "form-control", placeholder: "e.g. Estimator" %>
+        <div class="form-text">Shown in the email signature.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.telephone_field :phone_number, class: "form-control", placeholder: "(214) 555-0100" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :location_id, "Location", class: "form-label" %>
+        <%= f.collection_select :location_id, @location_options, :id, :display_name,
+              { include_blank: "— None (account admin) —" },
+              class: "form-select" %>
+        <div class="form-text">Originators are scoped to one location. Leave blank to make this user a tenant admin.</div>
+      </div>
+
+      <div class="d-flex gap-2">
+        <%= f.submit "Save", class: "btn btn-primary" %>
+        <%= link_to "Cancel", admin_tenant_path(@tenant), class: "btn btn-outline-secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     resources :tenants, only: [:index, :show, :new, :create, :edit, :update] do
       resources :invitations, only: [:create, :destroy]
       resources :locations, only: [:new, :create]
+      resources :users, only: [:edit, :update]
       resource :activations, only: [:show], controller: "activations"
       resources :job_type_activations, only: [:create, :destroy] do
         member { post :activate_all_scenarios }

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = users(:admin)
+    @non_admin = users(:one)
+    @tenant = tenants(:one)
+    @teammate = User.create!(email: "admin-edit-victim@example.com", password: "Password1", is_pending: false, tenant: @tenant)
+  end
+
+  test "non-admin cannot reach the admin user edit page" do
+    sign_in @non_admin
+    get edit_admin_tenant_user_url(@tenant, @teammate)
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot update via the admin path" do
+    sign_in @non_admin
+    patch admin_tenant_user_url(@tenant, @teammate), params: { user: { first_name: "Hax" } }
+    assert_redirected_to root_path
+    assert_nil @teammate.reload.first_name
+  end
+
+  test "admin sees the edit form" do
+    sign_in @admin
+    get edit_admin_tenant_user_url(@tenant, @teammate)
+    assert_response :success
+    assert_select "form input[name='user[first_name]']"
+    assert_select "form input[name='user[last_name]']"
+    assert_select "form input[name='user[title]']"
+    assert_select "form input[name='user[phone_number]']"
+    assert_select "form select[name='user[location_id]']"
+  end
+
+  test "admin can update name, title, phone, and location with audit log" do
+    location = locations(:ne_dallas)
+    sign_in @admin
+
+    assert_difference "AuditLog.count", 1 do
+      patch admin_tenant_user_url(@tenant, @teammate), params: { user: {
+        first_name: "Pat", last_name: "Quinn",
+        title: "Estimator", phone_number: "(214) 555-1212",
+        location_id: location.id
+      } }
+    end
+    assert_redirected_to admin_tenant_path(@tenant)
+    @teammate.reload
+    assert_equal "Pat", @teammate.first_name
+    assert_equal "Quinn", @teammate.last_name
+    assert_equal "Estimator", @teammate.title
+    assert_equal "(214) 555-1212", @teammate.phone_number
+    assert_equal location, @teammate.location
+
+    log = AuditLog.where(target_type: "User", target_id: @teammate.id, action: "user.update").last
+    assert_equal @admin, log.actor_user
+    assert_equal "Pat", log.payload["after"]["first_name"]
+  end
+
+  test "admin update drops a tampered location_id from another tenant" do
+    other_tenant = Tenant.create!(name: "OtherCo-admin-edit")
+    foreign_location = other_tenant.locations.create!(
+      display_name: "Foreign", address_line_1: "9 Foreign", city: "Reno",
+      state: "NV", postal_code: "89501", phone_number: "(775) 555-0303", is_active: true
+    )
+    sign_in @admin
+
+    patch admin_tenant_user_url(@tenant, @teammate), params: { user: {
+      first_name: "Pat", location_id: foreign_location.id
+    } }
+    assert_redirected_to admin_tenant_path(@tenant)
+    @teammate.reload
+    assert_equal "Pat", @teammate.first_name
+    assert_nil @teammate.location_id, "cross-tenant location_id must be dropped"
+  end
+
+  test "admin gets a friendly redirect when the user isn't in the tenant" do
+    other_tenant = Tenant.create!(name: "OtherCo-edit-mismatch")
+    outsider = User.create!(email: "outsider-admin-edit@example.com", password: "Password1", is_pending: false, tenant: other_tenant)
+    sign_in @admin
+    get edit_admin_tenant_user_url(@tenant, outsider)
+    assert_redirected_to admin_tenant_path(@tenant)
+    assert_match(/not found in this tenant/i, flash[:alert].to_s)
+  end
+
+  test "admin tenant show renders an Edit link for each user" do
+    sign_in @admin
+    get admin_tenant_url(@tenant)
+    assert_response :success
+    assert_select "a[href=?]", edit_admin_tenant_user_path(@tenant, @teammate), text: "Edit"
+  end
+end


### PR DESCRIPTION
## Summary

SMAI staff can now edit a user's first name, last name, title, phone number, and location from the admin tenant page — same surface a tenant admin gets on `/users/:id/edit`, but reachable from the SMAI admin namespace.

- New route: `/admin/tenants/:tenant_id/users/:id/edit, update`.
- `Admin::UsersController` (inherits `Admin::BaseController`, so SMAI staff only).
- Loads the user via `@tenant.users.find_by` so a cross-tenant id 404s with a clear flash.
- Same `EDITABLE_PARAMS` as the operator path. A tampered `location_id` from another tenant is dropped before update.
- Update writes an `AuditLog` row attributed to the SMAI admin actor.
- Edit link added to each row of the admin tenant show users table.

## Test plan

- [x] `rails test` — 697 runs, 0 failures.
- [ ] Smoke: as an SMAI admin, visit /admin/tenants/:id, click Edit on a user, change name + title + location, save, confirm the update + AuditLog row.
- [ ] Smoke: as a non-admin, hitting the URL directly should bounce to root with the standard "not authorized" alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)