### PR TITLE
docs(user guide): refresh §1–§4 for the week of 2026-05-09

### DIFF
--- a/docs/user-guide/01-job-types-and-campaigns.md
+++ b/docs/user-guide/01-job-types-and-campaigns.md
@@ -2,7 +2,7 @@
 
 > Audience: **system admin**.
 >
-> Everything in this section is under the **Admin** group in the sidebar — only admins see it. If you don't see the Admin group, you don't have admin rights yet.
+> Everything in this section is under the **Platform Admin** group in the sidebar — only admins see it. If you don't see the Platform Admin group, you don't have admin rights yet.
 
 There are three layers to set up, in this order:
 
@@ -16,7 +16,7 @@ The five restoration job types and seventeen restoration scenarios are present o
 
 ## 1.1 Create a job type
 
-1. **Sidebar → Admin → Job Types**.
+1. **Sidebar → Platform Admin → Job Types**.
 2. Click **+ New job type**.
 3. Fill in:
    - **Name** — what teammates and tenants see in the product (e.g. *Mold Remediation*).
@@ -28,25 +28,26 @@ You only need this step when adding a new category beyond the five that ship wit
 
 ## 1.2 Add scenarios under the job type
 
-1. **Sidebar → Admin → Job Types**, then click the job type to open it.
-2. The page lists the scenarios already under it. Click **+ New scenario**.
+1. **Sidebar → Platform Admin → Job Types**, then click the job type to open it.
+2. The page lists the scenarios already under it. Click **+ New Scenario**.
 3. Fill in:
    - **Code** — short, lowercase, with underscores (e.g. *pipe_burst*). Must be unique within this job type. Used internally to match the scenario to its email template; once chosen, do not change it.
    - **Short name** — what teammates see when picking a scenario in the product (e.g. *Pipe burst*).
    - **Description** — a one- or two-sentence summary of the situation.
-4. Click **Save changes**.
+4. Click **Save**.
 
-> The **Campaign** picker on this form is empty until the scenario is saved. You'll come back here in §1.6 after building the campaign in [§1.3](#13-create-a-campaign).
+> The **Campaign** picker on this form is locked until the scenario is saved. You'll come back here in §1.6 after building the campaign in [§1.3](#13-create-a-campaign).
 
 ## 1.3 Create a campaign
 
-1. **Sidebar → Admin → Campaigns**.
-2. Click **+ New campaign**.
+1. **Sidebar → Platform Admin → Campaigns**.
+2. Click **New campaign**.
 3. Fill in:
    - **Name** — a label only admins see when picking the campaign (e.g. *Pipe Burst — v1*).
-   - **Status** — leave as **New** while you're still writing the steps. You'll move it to **Approved** in [§1.5](#15-approve-pause-and-edit-the-campaign).
    - **Attributed to scenario** — pick which scenario this campaign is for. Only one campaign can be attributed to a scenario at a time, and only campaigns attributed to a scenario will be selectable on that scenario's edit page.
 4. Click **Save**.
+
+The campaign starts life as a **Draft** — invisible to tenants. You'll move it to **Approved** in [§1.5](#15-approve-pause-and-edit-the-campaign) after writing the steps.
 
 You land on the campaigns list. Open the campaign you just created to add steps.
 
@@ -56,10 +57,9 @@ On the campaign page:
 
 1. Click **Add step**.
 2. Fill in:
-   - **Sequence number** — the position in the sequence. The form defaults to the next slot, so usually you can leave this alone.
-   - **Offset (min)** — how many minutes after the previous step's send the next email should go out. For step 1, it's the wait after the campaign starts (use *0* to send immediately).
-   - **Template subject** — the email subject line. You can include merge fields (e.g. for the customer's name); your template author will know which ones are available.
-   - **Template body** — the email body. Same merge-field rules as the subject.
+   - **Offset** — three fields (days / hours / minutes) for how long after the previous step's send the next email should go out. For step 1, it's the wait after the campaign starts. Zero across all three fields = sends immediately.
+   - **Subject** — the email subject line. You can include merge fields (e.g. `{customer_first_name}`); the form's reference panel lists every available token with sample values.
+   - **Body** — the email body. Same merge-field rules as the subject. A standard signature block (with the proposal owner's name and your tenant's branding) is appended automatically — don't paste one into the template yourself.
 3. Click **Save**.
 
 Repeat for each step. To reorder steps, drag the row by the handle on the left — the numbers update to match.
@@ -68,9 +68,11 @@ Repeat for each step. To reorder steps, drag the row by the handle on the left �
 
 The buttons at the top of the campaign page change based on its current status:
 
-- **Approve** (visible when the campaign is **New**) — flips it to **Approved**. The campaign won't be used for any tenant uploads until you do this.
-- **Pause** (visible when the campaign is **Approved**) — flips it to **Paused**. Every running customer email sequence on this campaign halts. Reach for this when you've spotted something wrong with the content; for one-off pauses on a single proposal use [§4c](04-campaign-maintenance.md#4c-pausing--unpausing-a-campaign) instead.
-- **Approve** again (visible when the campaign is **Paused**) — flips it back to **Approved**, and running sequences resume from where they left off.
+- **Approve** (visible when the campaign is **Draft**) — flips it to **Approved**. The campaign won't be used for any tenant uploads until you do this.
+- **Pause** (visible when the campaign is **Approved**) — flips it to **Paused**. Every running customer email sequence on this campaign halts. Reach for this when you've spotted something wrong with the content; for one-off pauses on a single job use [§4c](04-campaign-maintenance.md#4c-pausing--unpausing-a-campaign) instead.
+- **Unpause** (visible when the campaign is **Paused**) — flips it back to **Approved**, and running sequences resume from where they left off.
+
+The page also records who approved or paused the campaign, with a timestamp, so you can see the history at a glance.
 
 You can edit the campaign name and steps at any status. Already-running customer sequences keep using the version of the content they started with — your edits affect new sequences only.
 
@@ -78,9 +80,9 @@ You can edit the campaign name and steps at any status. Already-running customer
 
 Once the campaign is **Approved**, finish the loop:
 
-1. **Sidebar → Admin → Job Types →** *(the job type)* **→** *(the scenario)*.
+1. **Sidebar → Platform Admin → Job Types →** *(the job type)* **→** *(the scenario)*.
 2. Click **Edit**.
 3. The **Campaign** picker now lists the campaign you attributed to this scenario in §1.3. Pick it.
-4. Click **Save changes**.
+4. Click **Save**.
 
-That scenario will now use this campaign for any new proposal that comes in matching it ([§4a](04-campaign-maintenance.md#4a-upload-a-job-to-start-a-campaign)).
+That scenario will now use this campaign for any new job that comes in matching it ([§4a](04-campaign-maintenance.md#4a-upload-a-job-to-start-a-campaign)).

--- a/docs/user-guide/02-tenant-onboarding.md
+++ b/docs/user-guide/02-tenant-onboarding.md
@@ -2,47 +2,67 @@
 
 > Audience: **system admin**.
 >
-> A tenant is one customer company. Everything that company touches — its users, organizations, locations, and proposals — lives under the tenant. Onboarding takes three steps: create the tenant, invite the first user, and turn on the job types and scenarios that company is allowed to use.
+> A tenant is one customer company. Everything that company touches — its users, locations, and proposals — lives under the tenant. Onboarding takes four steps: create the tenant, add at least one location, invite the first user, and turn on the job types and scenarios that company is allowed to use.
 
 ---
 
 ## 2.1 Create the tenant
 
-1. **Sidebar → Admin → Tenants**.
-2. Click **+ New tenant**.
-3. Enter the **Name** — the customer's company name as it should appear in the product (e.g. *Demo Roofing Co.*).
-4. Click **Save**.
+1. **Sidebar → Platform Admin → Tenant / Account**.
+2. Click **New tenant**.
+3. Enter the **Name** — the customer's company name as it should appear inside the admin UI (e.g. *Demo Roofing Co.*).
+4. Click **Create tenant**.
 
-You land on the tenant page. A top-level organization with the same name is created automatically; this is the company's default org. If the customer has branches or business units, more organizations can be added later from this page.
+You land on the tenant page. From here you can add locations, invite users, edit the customer-facing branding, and manage activations.
 
-## 2.2 Add a location for the organization
+## 2.2 Fill in the tenant's customer-facing details
 
-The location's address and phone number show up at the bottom of every campaign email the company sends, so set this up now — without it, the first emails go out missing the office details customers expect to see.
+Click **Edit** at the top right of the tenant page to open the tenant edit form. The fields here flow into every campaign email the company sends, so set them up early:
 
-1. From the tenant page, click **Organizations →** *(the organization)* **→ Locations → + Add Location**.
+- **Account name (internal)** — the same name you typed in §2.1. Shown only in the admin UI; safe to use a short nickname.
+- **Company name (customer-facing)** — what shows up in email signatures (e.g. *Demo Roofing Co.*). If left blank, the account name is used.
+- **Logo (upload)** — drop a PNG, JPG, or SVG. Replaces any existing upload.
+- **Logo URL (manual override)** — used only when no file is uploaded. Point at a logo hosted elsewhere.
+- **Require DASH job number** — turn on for restoration tenants who track every job in DASH. When on, every proposal needs a DASH number before it can be approved, and the number is prefixed onto every campaign email subject so the thread stays threaded in DASH.
+
+Click **Save** when you're done.
+
+## 2.3 Add a location
+
+The location's address and phone number show up at the bottom of every campaign email the company sends, so set this up before inviting users — without it, the first emails go out missing the office details customers expect to see.
+
+1. On the tenant page, find the **Locations** card and click **Add location**.
 2. Fill in:
-   - **Display name** — how the location should appear (e.g. *Naperville HQ*).
-   - **Address** — street, city, state, postal code.
-   - **Phone**.
-   - **Active** — check this so emails use this location.
-3. Click **Save**.
+   - **Display name** — how the location should appear in the operator UI and email signatures (e.g. *NE Dallas*).
+   - **Address line 1**, optional **Address line 2**, **City**, **State** (two-letter US code), **Postal code**.
+   - **Phone number** — office phone, used in email signatures.
+   - **Active** — check this box so users can be assigned here and the location is visible to operators. A location stays inactive until every required field above is filled in.
+3. Click **Create Location**.
 
-The customer can edit their own location later from their **My Organization** page (see [§3.4](03-user-onboarding-and-account.md#34-editing-your-profile-and-organization)).
+You land back on the tenant page with the new location in the **Locations** card. Add more locations the same way for tenants with multiple branches.
 
-## 2.3 Invite the first user
+## 2.4 Invite the first user
 
-The first invitation usually goes to the company owner or office manager so they can invite the rest of the team themselves.
+The first invitation usually goes to the company's account admin (often the owner or office manager) so they can invite the rest of the team themselves.
 
-1. On the tenant page, find the **Invite a user** card on the right.
-2. Enter the recipient's email address and click **Send invite**.
+1. On the tenant page, find the **Invite a user** card on the right and click **Invite user**. A dialog opens.
+2. Fill in:
+   - **First name** and **Last name**.
+   - **Email address**.
+   - **Title** — shown in the email signature (e.g. *Estimator*).
+   - **Phone number**.
+   - **Is Account Admin** — check this for the first invitee. Account admins aren't tied to a single location and can invite the rest of the team. Leave it unchecked for an originator, then pick the **Location** they should belong to.
+3. Click **Send invite**.
 
-The invitation email goes out immediately and includes a link that expires in seven days. Once sent, the email shows up in the **Pending invitations** list on this page along with when it was sent and when it will expire.
+The invitation email goes out immediately and includes a link that expires in seven days. Once sent, the email shows up in the **Pending invitations** list on this page along with when it was sent and when it will expire. If the invitee never uses the link, click **Revoke** to retract it.
 
-> Once a user has accepted, they can invite the rest of their team themselves from the **Users** page — see [§3.6](03-user-onboarding-and-account.md#36-inviting-teammates).
+> If the **Invite user** button is hidden and the card shows a yellow warning, the install isn't ready to send invitations yet — typically because the application mailbox isn't connected ([§0.9](00-production-setup.md#09-connect-the-application-mailbox)) or `APP_HOST` isn't set ([§0.5](00-production-setup.md#05-production-url-host)). Fix the listed blockers and the button comes back.
+>
+> Once a user has accepted, they can invite the rest of their team themselves from the **Team** page — see [§3.6](03-user-onboarding-and-account.md#36-inviting-teammates).
 
-## 2.4 Activate job types and scenarios
+## 2.5 Activate job types and scenarios
 
-Each tenant only sees the job types and scenarios you turn on for them. This lets you onboard a roofing company differently from a restoration company, even though both use the same SMAI install.
+Each tenant only sees the job types and scenarios you turn on for them. This lets you onboard a roofing company differently from a restoration company, even though both use the same install.
 
 1. On the tenant page, click **Manage activations** (top right).
 2. You'll see a table of every job type with each scenario indented underneath.
@@ -55,13 +75,13 @@ A scenario can't be activated unless its parent job type is already active — t
 
 The pre-built **Demo Roofing Co.** tenant has all five restoration job types and all seventeen scenarios already activated, so you can use it as a reference for what a fully-set-up tenant looks like.
 
-## 2.5 Confirm the result
+## 2.6 Confirm the result
 
 Back on the tenant page, you should see:
 
-- The organization with a populated **Location** card.
+- The **Locations** card populated with at least one active location.
 - The invitation you sent under **Pending invitations**, with sent and expiry times.
 - The **Users** list will fill in as people accept their invitations ([§3.1](03-user-onboarding-and-account.md#31-accepting-an-invitation)).
-- The **Manage activations** link reflects the count of what you turned on in [§2.4](#24-activate-job-types-and-scenarios).
+- The **Manage activations** link reflects the count of what you turned on in [§2.5](#25-activate-job-types-and-scenarios).
 
 The tenant is ready. The next time someone there uploads a proposal, the system will recognize the work, pick the matching scenario, and start the right campaign.

--- a/docs/user-guide/03-user-onboarding-and-account.md
+++ b/docs/user-guide/03-user-onboarding-and-account.md
@@ -15,19 +15,22 @@ When someone invites you, you'll get an email with a link to join. The link work
 1. Click the link in the email.
 2. You'll land on a sign-up page with your email already filled in.
 3. Pick a password and submit.
-4. You're signed in. Your company and organization are set automatically.
+4. You're signed in. Your company and (if you were invited as an originator) your location are set automatically.
 
 **If you already have an account:**
 
 1. Sign in first if you aren't already.
 2. Click the link in the email.
-3. You'll be added to the company and organization right away, and you'll see a welcome message.
+3. You'll be added to the company right away, and you'll see a welcome message.
 
 Each invitation link can only be used once. If yours has expired or you can't find it, ask whoever invited you to resend.
 
 ## 3.2 Signing in
 
-Go to the sign-in page and enter your email and password. After signing in, you'll land on the home page with cards for **Proposals**, **Needs Attention**, **Co-workers**, and **Analytics**, and the sidebar will show **Job Proposals** and **Co-workers**. If you're an admin, you'll also see the **Admin** group below those.
+Go to the sign-in page and enter your email and password. After signing in, where you land depends on your role:
+
+- **Account admins and platform staff** see a home page with cards for **Proposals**, **Needs Attention**, **Team**, and **Analytics**, and the sidebar shows **Needs Attention**, **Jobs**, **Analytics**, and **Team**. Platform staff also see a **Platform Admin** group below those.
+- **Originators** (users assigned to a single location) skip the home page and land directly on **Needs Attention** — the same items they'll need to act on most days.
 
 ## 3.3 I forgot my password
 
@@ -40,13 +43,15 @@ The reset link expires after about six hours. If yours has expired, just request
 
 > If you're already signed in and just want to change your password — for example, you're rotating it on a schedule — use the **Change password** link in your profile menu instead.
 
-## 3.4 Editing your profile and organization
+## 3.4 Your profile
 
-From the menu in the top corner (or your profile link):
+Open the menu in the top-right corner of any page and pick **Profile**.
 
-- **Profile** — update your first name, last name, and email. Your name is what teammates see on the **Job Proposals** index and on invitations you've sent. If you don't have a name set, your email is shown instead.
-- **Change password** — rotate your password. You'll need your current password to confirm.
-- **My Organization** — see your company's tenant, your organization, and your office location. The location is editable here; everything else is read-only and managed by your admin.
+The profile page shows your name, title, phone, email, the company you belong to, your location (blank for account admins), your role, when you last signed in, and any Google accounts you've connected for sending email.
+
+- **Edit** (top right of the Profile card) — update your first name, last name, title, and phone number. Your name and title are what teammates see on the **Jobs** index and what shows up in the email signature on every campaign email you send. If you don't have a name set, your email is shown instead and a banner reminds you to fill it in.
+- **Change password** (in the top-right menu) — rotate your password. You'll need your current password to confirm.
+- **Role badges** — your profile shows **Application Admin** if you're platform staff, **Tenant Admin** if you're an account admin for your company, or no badge if you're an originator. These are managed by your admin and can't be changed from the profile page.
 
 ## 3.5 Connected email accounts
 
@@ -54,8 +59,8 @@ From the menu in the top corner (or your profile link):
 
 The system uses a Google account to send mail. There are two places a Google account gets connected, and they're for different things:
 
-- **The application mailbox** (admin-only, **Admin → Mailbox**). This is the Google account the *system* sends from — every customer-facing campaign email and every invitation goes from this address. There is one application mailbox for the whole install.
-- **Your personal Google connection** (under your profile). You can connect your own Google account here, but at the moment the system doesn't send from personal accounts — the option is there for future "send as you" features and connecting one today doesn't change anything.
+- **The application mailbox** (admin-only, **Platform Admin → Mailbox**). This is the Google account the *system* sends from — every customer-facing campaign email and every invitation goes from this address. There is one application mailbox for the whole install.
+- **Your personal Google connection** (under your profile, the **Email sending** card). You can connect your own Google account here, but at the moment the system doesn't send from personal accounts — the option is there for future "send as you" features and connecting one today doesn't change anything.
 
 For day-to-day work, the only Google connection that matters is the application mailbox. If it's connected and healthy, mail goes out. If it isn't, nothing does.
 
@@ -64,16 +69,16 @@ For day-to-day work, the only Google connection that matters is the application 
 The most common cause is a revoked or expired Google connection on the application mailbox. Connections can break when:
 
 - Whoever owns the connected Google account revokes access from their Google account settings.
-- A Google Workspace admin removes the SMAI app from the workspace's allow-list, or deactivates the connected user.
+- A Google Workspace admin removes the app from the workspace's allow-list, or deactivates the connected user.
 - The connected account is deleted or rotated.
 
 When this happens, the system stops sending campaign emails for affected proposals. Customer-reply detection still works, but new outbound steps wait silently. There's no email alert today; the way you find out is that someone notices customers haven't been hearing from them.
 
-> **Quick check:** an admin can open **Admin → Integrations** to see the live status of the application mailbox along with every other external service the app depends on. A red **Missing** row on the mailbox is the unambiguous tell.
+> **Quick check:** an admin can open **Platform Admin → Integrations** to see the live status of the application mailbox along with every other external service the app depends on. A red **Missing** row on the mailbox is the unambiguous tell.
 
 **The fix is always the same:**
 
-1. An admin opens **Admin → Mailbox**.
+1. An admin opens **Platform Admin → Mailbox**.
 2. Clicks **Connect a Gmail account**.
 3. Signs in to the Google account that should be the sender and approves the access request.
 4. After connecting, an admin should also resume any campaigns that were marked as having a delivery problem — see [§4d](04-campaign-maintenance.md#4d-customer-responds).
@@ -83,19 +88,27 @@ When this happens, the system stops sending campaign emails for affected proposa
 For production, it's worth using a dedicated Google Workspace user (something like `outreach@yourcompany.com`) rather than someone's personal Gmail. Three reasons:
 
 1. **Stability.** A personal account leaves with the person; a dedicated address stays.
-2. **Sender identity.** The "from" line on every campaign email is the connected address, so it should match the brand customers expect.
+2. **Sender identity.** The "from" line on every campaign email is the connected address paired with the proposal owner's name, so the address should match the brand customers expect.
 3. **Scale.** Workspace accounts have higher sending limits than personal Gmail. Personal Gmail is fine for testing or staging but isn't a good production choice.
 
-If you're on Google Workspace, ask your Workspace admin to allow the SMAI app for that account before connecting — otherwise consent may be blocked at sign-in.
+If you're on Google Workspace, ask your Workspace admin to allow the app for that account before connecting — otherwise consent may be blocked at sign-in.
 
 ## 3.6 Inviting teammates
 
-Once you have an account, you can invite teammates yourself.
+Once you have an account *and* you're an account admin, you can invite teammates yourself. Originators (users tied to a single location) don't see the invite button — ask your account admin to invite the new teammate.
 
-1. **Sidebar → Co-workers**.
-2. Click **Invite user** (top right).
-3. Enter the teammate's email address and click **Send invite**.
+1. **Sidebar → Team**.
+2. Click **Invite user** (top right). A dialog opens.
+3. Fill in:
+   - **First name** and **Last name**.
+   - **Email address**.
+   - **Title** — shown in the email signature (e.g. *Estimator*).
+   - **Phone number**.
+   - **Is Account Admin** — check this if the invitee should be able to invite other teammates and see proposals across every location. Leave it unchecked for an originator, then pick the **Location** they should belong to.
+4. Click **Send invite**.
 
-The invitation goes out right away. The new person gets the same link-based flow described in [§3.1](#31-accepting-an-invitation), and the link expires in seven days. Their pending invite shows up on the **Co-workers** page with who sent it and when it expires.
+The invitation goes out right away. The new person gets the same link-based flow described in [§3.1](#31-accepting-an-invitation), and the link expires in seven days. Their pending invite shows up under **Pending invitations** with who sent it and when it expires. Click **Revoke** if you sent it to the wrong address or no longer want them to join.
 
-If you don't see the **Invite user** button, your account isn't tied to a company yet — ask an admin to add you.
+The **Team** table also shows a **Role** column (Admin / Originator) and a **Gmail** column (Linked / Not linked) so you can see at a glance who can do what.
+
+If the **Invite user** button is hidden and the dialog shows a yellow warning instead of the form, the install isn't ready to send invitations yet — most often because the application mailbox isn't connected. Ask your admin to check **Platform Admin → Integrations**.

--- a/docs/user-guide/04-campaign-maintenance.md
+++ b/docs/user-guide/04-campaign-maintenance.md
@@ -2,82 +2,87 @@
 
 > Audience: **tenant user**.
 >
-> Day-to-day work happens against job proposals. Each upload becomes a proposal, the system kicks off the right campaign, and you monitor and intervene from the proposal index.
+> Day-to-day work happens against jobs. Each upload becomes a job (a "proposal" in product language), the system kicks off the right campaign, and you monitor and intervene from the Jobs index.
 
 ---
 
 ## 4a. Upload a job to start a campaign
 
-1. **Sidebar → Job Proposals**.
-2. Click **+ New job** (top right). A drag-and-drop zone appears.
-3. Drop your PDF estimate or proposal onto the zone, or click it to pick a file from your computer. The **Upload** button enables once a file is selected.
-4. Click **Upload**.
+1. **Sidebar → Jobs**, then **New Job** (top right). You can also use the **+** button in the top navbar from anywhere in the app. A drag-and-drop zone appears.
+2. Drop your PDF estimate or proposal onto the zone, or click it to pick a file from your computer. The **Upload** button enables once a file is selected.
+3. Click **Upload**. The button shows a progress message — large files plus AI extraction can take a few seconds, so don't click again.
 
-You land on a **Confirm** page that previews everything the system pulled out of the PDF — the customer's title, name, email, and address; the job type and scenario; the proposal value; and the internal reference. Read it over and fix anything that's wrong. When you're satisfied, click **Save**. The system files the proposal and starts the campaign for the chosen scenario. The first email goes out on the cadence the admin set up for that campaign.
+You land on a **Confirm** page that previews everything the system pulled out of the PDF — the customer's title, name, email, and address; the job type and scenario; the proposal value; the internal reference; and (if your tenant requires it) the DASH job number. Read it over and fix anything that's wrong. When you're satisfied, click **Approve Proposal Content**. The job is filed and the campaign for the chosen scenario starts. The first email goes out on the cadence the admin set up for that campaign.
 
 A few practical notes:
 
-- **Confirm before you save.** This is the only chance to correct the data before the first email goes out. Once you save with a scenario picked, the campaign is in flight and the proposal is locked for editing.
-- **Reassigning ownership.** If you're uploading on behalf of a teammate (e.g. an assistant uploading for a project manager), use the **Owner** field on the Confirm page to point the proposal at the right person before saving.
-- **No scenario yet?** You can save without one — the proposal is filed but no campaign starts. Pick a scenario later from the proposal's edit page when you're ready (note: once a campaign is running, you can't go back and change it).
-- **Job type or scenario not activated for your tenant?** No campaign starts. The proposal is still saved, but it sits idle until your admin activates the matching job type and scenario for your tenant ([§2.4](02-tenant-onboarding.md#24-activate-job-types-and-scenarios)).
+- **Confirm before you approve.** This is the only chance to correct the data before the first email goes out. Once you approve with a scenario picked, the campaign is in flight and the job is locked for editing.
+- **Reassigning ownership.** If you're uploading on behalf of a teammate (e.g. an assistant uploading for a project manager), use the **Owner** field on the Confirm page to point the job at the right person before approving. The owner's name appears on the From line of every campaign email.
+- **Reassigning location.** Account admins see an editable **Location** field; originators see the location as a read-only summary (whatever location they're assigned to is the one the job belongs to).
+- **DASH job number required?** If your tenant has DASH numbering turned on, the **DASH job number** field is required before you can approve. Once set, that number is prefixed onto every campaign email subject so the conversation stays threaded in DASH.
+- **No scenario yet?** You can save without one — the job is filed but no campaign starts. Pick a scenario later from the job's edit page when you're ready (note: once a campaign is running, you can't go back and change it).
+- **Job type or scenario not activated for your tenant?** No campaign starts. The job is still saved, but it sits idle until your admin activates the matching job type and scenario for your tenant ([§2.5](02-tenant-onboarding.md#25-activate-job-types-and-scenarios)).
 - **Upload error?** A red banner at the top of the page explains what went wrong (e.g. unreadable file, missing tenant assignment). Fix the listed issue and try again.
 
-## 4b. The proposal status board
+## 4b. The Jobs board
 
-**Sidebar → Job Proposals** is your operating board. Each row is one proposal.
+**Sidebar → Jobs** is your operating board. Each job is shown as a card. Originators see only jobs at their location; account admins see every job in the company.
 
 **Filter the board** with the controls along the top:
 
 - **Search** — customer name, address fragment, or internal reference.
+- **Location** — narrow to a single office (account admins only).
 - **Status** — *new* (just uploaded), *open* (campaign running), or *closed* (won or lost).
 - **Owner** / **Created by** — narrow to a specific teammate.
-- **Sort** — click the **Proposal value** or **Created** column header to sort. Your filters are kept when you sort, and your sort is kept when you re-filter.
 
-**What each column shows:**
+**What each card shows:**
 
-- **Address** — click it to open the proposal.
-- **Customer** — first and last name. A dash means the system couldn't pull a name from the file; open the proposal to fill it in.
-- **Organization** — which of your tenant's organizations owns the proposal (only matters if you have more than one).
-- **Job Type** — what kind of work the system inferred from the upload. A dash means it couldn't tell.
-- **Status** — *new*, *open*, or *closed*.
-- **Proposal value** — the total amount, formatted as currency.
-- **Owner** / **Created by** — who owns the proposal, and who uploaded it.
-- **Created** — the day it was uploaded.
-- **Action** — a single button telling you what to do next on this row. The button changes based on the proposal's state:
-  - **View job** — the campaign is running normally, or the proposal is closed (won/lost). Opens the proposal's detail page.
+- **Customer name** and **proposal value** along the top of the card, in bold.
+- **Address** as the main subtitle. Click anywhere on the card body to open the job's detail page.
+- A footer line with the **location** (account admins only), the **job type**, and a status overlay if there's anything noteworthy (e.g. *paused*, *waiting on the customer*, *delivery issue*).
+- An **action button** on the right telling you what to do next on this job. The button changes based on the job's state:
+  - **View job** — the campaign is running normally, or the job is closed (won/lost). Opens the job's detail page.
   - **Open in Gmail** — the customer has replied. Opens the conversation in a new Gmail tab so you can read the full message and respond from your inbox.
-  - **Fix delivery issue** — the campaign couldn't deliver an email (bad address, mailbox bounced). Opens the proposal's edit page so you can correct the customer's email.
+  - **Fix delivery issue** — the campaign couldn't deliver an email (bad address, mailbox bounced). Opens the job's edit page so you can correct the customer's email.
   - **Resume campaign** — the campaign was paused. Click to resume; the next step picks up on the cadence.
+  - **Review** — the job was uploaded but the Confirm page is still pending. Opens the Confirm page so you can finalize and approve it.
 
-Click an address to open the proposal. The detail page shows a **Customer** card, a **Job** card, an **Ownership** card, and (when the customer has replied) the most recent reply.
+The job's detail page shows a **Customer** card, a **Job** card with status and pipeline stage, a **Campaign** card with each step's send status, an **Ownership** card (location, owner, who created it), and any uploaded files.
 
 ## 4c. Pausing & unpausing a campaign
 
-> Pause a single proposal's campaign when the customer asks for a delay or you've learned something that should keep emails from going out (vacation, traveling, escrow, family emergency). Pause the campaign *template* — different action, admin-only ([§1.5](01-job-types-and-campaigns.md#15-approve-pause-and-edit-the-campaign)) — when the content itself needs a fix.
+> Pause a single job's campaign when the customer asks for a delay or you've learned something that should keep emails from going out (vacation, traveling, escrow, family emergency). Pause the campaign *template* — different action, admin-only ([§1.5](01-job-types-and-campaigns.md#15-approve-pause-and-edit-the-campaign)) — when the content itself needs a fix.
 
-**Pausing.** *Not yet built.* The button to pause an individual proposal's campaign isn't in the product yet. Until it ships, ask an admin to pause for you.
+**Pausing.** Open the job's detail page and click **Pause** in the top action bar. The button is only there while the campaign is actively running — once you pause, all scheduled steps stop. The job's row on the **Jobs** board flips to a **Resume campaign** action.
 
-**Resuming.** When a proposal's campaign is paused, its row on the **Job Proposals** index shows a **Resume campaign** button in the **Action** column. Click it; the campaign goes back to running on the cadence the admin set up.
+**Resuming.** From the **Jobs** board, click **Resume campaign** on the paused row (the same button is also available on the job's detail page when the campaign is paused). The campaign goes back to running on the cadence the admin set up.
 
 > *Note:* today, after a long pause, any campaign steps whose scheduled time fell inside the pause window will fire on the next sweep — not be retroactively skipped. If that's not what you want, hold off on resuming until the gap is small.
 
 ## 4d. Customer responds
 
-When a customer replies to a campaign email, the system stops sending — no more follow-ups go out on that thread. The proposal is flagged as **waiting on the customer** so you can spot it on the board.
+When a customer replies to a campaign email, the system stops sending — no more follow-ups go out on that thread. The job is flagged as **waiting on the customer** so you can spot it on the board.
 
-What you'll see on the **Job Proposals** index:
+What you'll see on the **Jobs** board:
 
-- The row's **Action** button reads **Open in Gmail** — click it to jump straight to the conversation in a new tab and reply from your usual inbox.
-- The most recent reply (sender, time, subject, and a short preview) appears on the proposal's detail page.
+- The card's action button reads **Open in Gmail** — click it to jump straight to the conversation in a new tab and reply from your usual inbox.
+- The most recent reply (sender, time, subject, and a short preview) appears on the job's detail page.
 
 What to do:
 
-1. **Click Open in Gmail** on the proposal's row. Read the full thread and respond.
-2. **When the deal is decided**, mark the proposal won or lost ([§4e](#4e-marking-a-proposal-as-won--lost)).
+1. **Click Open in Gmail** on the job's card. Read the full thread and respond.
+2. **When the deal is decided**, mark the job won or lost ([§4e](#4e-marking-a-job-as-won--lost)).
 
-> **Delivery problem instead of a reply?** If the campaign couldn't deliver an email (bad address, the customer's mailbox bounced it), the row's **Action** button reads **Fix delivery issue**. Click it to open the proposal's edit page and correct the customer's email address. *Restarting the campaign from a delivery problem is not yet built* ([#117](https://github.com/frizman21/smai-server/issues/117)) — for now, ask an admin.
+> **Delivery problem instead of a reply?** If the campaign couldn't deliver an email (bad address, the customer's mailbox bounced it), the action button reads **Fix delivery issue**. Click it to open the job's edit page and correct the customer's email address. *Restarting the campaign from a delivery problem is not yet built* ([#117](https://github.com/frizman21/smai-server/issues/117)) — for now, ask an admin.
 
-## 4e. Marking a proposal as won / lost
+## 4e. Marking a job as won / lost
 
-> *Not yet built.* The **Mark Won** and **Mark Lost** buttons aren't in the product yet. This guide will be updated when they ship.
+Open the job's detail page. Two buttons sit in the top action bar next to the page title:
+
+- **Mark Won** — single click. The job's pipeline stage flips to *Won* and the campaign stops if it was still running.
+- **Mark Lost** — opens a small dialog. Both fields are required:
+  - **Loss reason** — a short label (e.g. *Price*, *Timing*, *No response*).
+  - **Loss notes** — any context worth recording about why the deal didn't move forward.
+  Click **Mark Lost** in the dialog to confirm.
+
+Once a job is Won or Lost, those buttons are replaced by **Revert to in campaign** — useful if you clicked the wrong one. Reverting puts the job back into its prior state.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # User Guide
 
-This guide walks through the day-to-day operation of SMAI from two perspectives:
+This guide walks through the day-to-day operation of the product from two perspectives:
 
 - **System admin** — owns the job types, scenarios, and campaigns, and onboards tenants.
 - **Tenant user** — runs jobs, monitors the proposal status board, and handles customer replies.
@@ -19,15 +19,15 @@ The sections below are written in the order you would touch them when standing t
 | 3 | [User Onboarding & Account Maintenance](03-user-onboarding-and-account.md) | Tenant user |
 | 4 | [Campaign Maintenance](04-campaign-maintenance.md) | Tenant user |
 | | &nbsp;&nbsp;4a. [Upload a job to start a campaign](04-campaign-maintenance.md#4a-upload-a-job-to-start-a-campaign) | |
-| | &nbsp;&nbsp;4b. [The proposal status board](04-campaign-maintenance.md#4b-the-proposal-status-board) | |
+| | &nbsp;&nbsp;4b. [The Jobs board](04-campaign-maintenance.md#4b-the-jobs-board) | |
 | | &nbsp;&nbsp;4c. [Pausing & unpausing a campaign](04-campaign-maintenance.md#4c-pausing--unpausing-a-campaign) | |
 | | &nbsp;&nbsp;4d. [Customer responds](04-campaign-maintenance.md#4d-customer-responds) | |
-| | &nbsp;&nbsp;4e. [Marking a proposal as won / lost](04-campaign-maintenance.md#4e-marking-a-proposal-as-won--lost) (not yet built) | |
+| | &nbsp;&nbsp;4e. [Marking a job as won / lost](04-campaign-maintenance.md#4e-marking-a-job-as-won--lost) | |
 
 ## Conventions used in this guide
 
 - **Paths** like `/admin/tenants` refer to the URL after your hostname (e.g. `https://app.example.com/admin/tenants`).
-- **Admin-only** screens require a user with the system-admin flag set. Tenant users do not see the **Admin** group in the sidebar.
+- **Admin-only** screens require a user with the system-admin flag set. Tenant users do not see the **Platform Admin** group in the sidebar.
 - The seeded restoration job types (Water Mitigation, Mold Remediation, Structural Cleaning, General Cleaning, Trauma / Biohazard) are referenced by their `type_code` in templates and specs.
 
 ## Suggesting changes


### PR DESCRIPTION
## Summary

The product moved fast this week and the operator-facing sections of the user guide drifted. Sweep §1–§4 (and the README index) to match what an operator now sees in the product.

Highlights:

- **§1 Job Types & Campaigns** — sidebar group is **Platform Admin**, campaign starts as **Draft** (was "New"), the Paused → Approved button is **Unpause**, step **Offset** is a days/hours/minutes triplet (no more "Offset (min)"), merge-field token format is documented (`{customer_first_name}`).
- **§2 Tenant Onboarding** — Organizations are gone; tenants own locations directly. New §2.2 documents the tenant edit form (logo upload, customer-facing company name, DASH-required toggle). The invite flow is now a modal that captures first/last name, title, phone number, an Account Admin checkbox, and a location pick.
- **§3 User Onboarding** — sidebar item is **Team** (was Co-workers). Sign-in lands on the home page for account admins / platform staff and on **Needs Attention** for originators. Removed the "My Organization" page (no longer exists). Profile now surfaces **Application Admin** / **Tenant Admin** role badges. Invite teammates uses the same modal as §2 and is gated on the Account Admin role.
- **§4 Campaign Maintenance** — sidebar/board renamed **Job Proposals → Jobs**. The index is now a card list, not a table — §4b is rewritten around card anatomy and the per-card action button. Pause (§4c) and Mark Won / Mark Lost (§4e) are no longer "not yet built": Pause sits in the proposal action bar while a campaign is active; Mark Lost opens a required-fields modal (loss reason + notes); a **Revert to in campaign** button is documented for accidental Won/Lost clicks. The Confirm-page submit button is **Approve Proposal Content** while the proposal is drafting.
- **README** — adjust the §4b anchor and the "Platform Admin" sidebar label.

## Pre-merge checklist (per CLAUDE.md)

- [x] Technical-leakage grep clean (\`JobProposal\`, \`CampaignInstance\`, \`gmail_thread_id\`, etc. — none in operator prose).
- [x] §-style cross-references resolve after the §2.4 → §2.5 renumber and the §4e anchor rename.
- [x] No "Co-workers", "My Organization", or "Sidebar → Admin" prefixes left over.

## Test plan

- [ ] Skim the rendered Markdown on GitHub for the renamed §4b anchor and the §2.5 cross-link.
- [ ] Confirm an account admin walking the §2 path can create a tenant, edit branding, add a location, invite a user, and activate scenarios end-to-end.
- [ ] Confirm an originator walking the §4 path sees the Jobs card list, can upload a job, pause from the detail page, and mark won/lost via the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)