### PR TITLE
Loss reasons: constrained table, FK, show-page card, and analytics pie

### DIFF
--- a/app/controllers/admin/job_proposals_controller.rb
+++ b/app/controllers/admin/job_proposals_controller.rb
@@ -3,7 +3,7 @@ class Admin::JobProposalsController < Admin::BaseController
     tenant_id location_id owner_id
     customer_title customer_first_name customer_last_name customer_email
     customer_house_number customer_street customer_city customer_state customer_zip
-    internal_reference loss_notes loss_reason
+    internal_reference loss_notes loss_reason_id
     job_type_id scenario_id proposal_value
   ].freeze
 
@@ -34,6 +34,7 @@ class Admin::JobProposalsController < Admin::BaseController
     @owner_options = tenant ? tenant.users.order(:email) : User.none
     @job_type_options = JobType.order(:name)
     @scenario_options = Scenario.includes(:job_type).order("job_types.name", :short_name)
+    @loss_reason_options = LossReason.ordered
   end
 
   def create_params

--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -5,7 +5,7 @@ class JobProposalsController < ApplicationController
   EDITABLE_PARAMS = %i[
     customer_title customer_first_name customer_last_name customer_email
     customer_house_number customer_street customer_city customer_state customer_zip
-    internal_reference dash_job_number loss_notes loss_reason
+    internal_reference dash_job_number loss_notes loss_reason_id
     owner_id job_type_id scenario_id proposal_value
   ].freeze
 
@@ -50,6 +50,7 @@ class JobProposalsController < ApplicationController
 
   def show
     @job_proposal = JobProposal.accessible_by(current_ability).find(params[:id])
+    @loss_reason_options = LossReason.ordered
   end
 
   def new
@@ -176,9 +177,10 @@ class JobProposalsController < ApplicationController
   end
 
   def mark_lost
-    reason = params[:loss_reason].to_s.strip
-    notes  = params[:loss_notes].to_s.strip
-    if reason.blank? || notes.blank?
+    reason_id = params[:loss_reason_id].presence
+    notes     = params[:loss_notes].to_s.strip
+    reason    = LossReason.find_by(id: reason_id)
+    if reason.nil? || notes.blank?
       redirect_to job_proposal_path(@job_proposal),
         alert: "Loss reason and loss notes are both required to mark a job lost."
       return
@@ -298,6 +300,7 @@ class JobProposalsController < ApplicationController
     @scenario_options = tenant.activated_scenarios.includes(:job_type).order("job_types.name", :short_name)
     @location_editable = !current_user.scoped_to_location?
     @location_options = @location_editable ? tenant.locations.order(:display_name) : Location.none
+    @loss_reason_options = LossReason.ordered
   end
 
   def proposal_params

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -6,6 +6,7 @@ class JobProposal < ApplicationRecord
   belongs_to :closed_by_user, class_name: "User", optional: true
   belongs_to :job_type, optional: true
   belongs_to :scenario, optional: true
+  belongs_to :loss_reason, optional: true
 
   has_many :attachments, class_name: "JobProposalAttachment", dependent: :destroy
   has_many :campaign_instances, as: :host, dependent: :destroy

--- a/app/models/loss_reason.rb
+++ b/app/models/loss_reason.rb
@@ -1,0 +1,8 @@
+class LossReason < ApplicationRecord
+  has_many :job_proposals, dependent: :restrict_with_error
+
+  validates :code, presence: true, uniqueness: true
+  validates :display_name, presence: true
+
+  scope :ordered, -> { order(:sort_order, :display_name) }
+end

--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -113,6 +113,26 @@ class AnalyticsCalculator
       .sort
       .to_h
 
+    # Loss-reason breakdown for the analytics pie. Lost proposals with no
+    # loss_reason_id (e.g. legacy rows the migration backfilled to NULL,
+    # or anything that slips past the controller validation in the future)
+    # are bucketed as "Unspecified" so the chart's slices add up to the
+    # full lost_count regardless.
+    loss_reasons_breakdown = @proposals
+      .where(pipeline_stage: :lost)
+      .left_outer_joins(:loss_reason)
+      .group("loss_reasons.id", "loss_reasons.display_name", "loss_reasons.sort_order")
+      .pluck(
+        "loss_reasons.id",
+        "loss_reasons.display_name",
+        "loss_reasons.sort_order",
+        Arel.sql("COUNT(*)")
+      )
+      .map { |id, label, sort_order, count|
+        { loss_reason_id: id, display_name: label || "Unspecified", sort_order: sort_order, count: count }
+      }
+      .sort_by { |row| [row[:sort_order] || Float::INFINITY, row[:display_name]] }
+
     OpenStruct.new(
       activated_count:          activated_count,
       first_followup_delivered: first_followup_delivered,
@@ -128,6 +148,7 @@ class AnalyticsCalculator
       follow_ups_sent:          follow_ups_sent,
       originators:              originators,
       follow_ups_by_day:        follow_ups_by_day,
+      loss_reasons_breakdown:   loss_reasons_breakdown,
       funnel_max:               [activated_count, 1].max,
       total_proposals:          @proposals.count
     )

--- a/app/views/admin/job_proposals/new.html.erb
+++ b/app/views/admin/job_proposals/new.html.erb
@@ -115,9 +115,10 @@
     <div class="card-body">
       <div class="row g-3">
         <div class="col-md-6">
-          <%= f.label :loss_reason, "Loss reason", class: "form-label" %>
-          <%= f.text_field :loss_reason, class: "form-control",
-                placeholder: "e.g. Price, Timing, No response" %>
+          <%= f.label :loss_reason_id, "Loss reason", class: "form-label" %>
+          <%= f.collection_select :loss_reason_id, @loss_reason_options, :id, :display_name,
+                { include_blank: "— None —" },
+                class: "form-select" %>
         </div>
         <div class="col-md-12">
           <%= f.label :loss_notes, "Loss notes", class: "form-label" %>

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -232,3 +232,77 @@
     <% end %>
   </div>
 </div>
+
+<%# --- Loss reasons --------------------------------------------------- %>
+<div class="card shadow-sm mb-4">
+  <div class="card-header"><h2 class="h5 mb-0">Why we lost</h2></div>
+  <div class="card-body">
+    <% if analytics.loss_reasons_breakdown.any? %>
+      <%# Six product reasons + an "Unspecified" fallback — pick a palette
+          big enough to cover all of them with distinct hues. %>
+      <% palette = %w[#0d6efd #198754 #ffc107 #0dcaf0 #dc3545 #6610f2 #6c757d] %>
+      <% total = analytics.loss_reasons_breakdown.sum { |r| r[:count] } %>
+      <%
+        cursor = 0.0
+        slices = analytics.loss_reasons_breakdown.each_with_index.map do |row, i|
+          start_pct = (cursor * 100).round(2)
+          fraction  = total.positive? ? row[:count].to_f / total : 0.0
+          cursor   += fraction
+          end_pct   = (cursor * 100).round(2)
+          {
+            row:        row,
+            color:      palette[i % palette.size],
+            from_pct:   start_pct,
+            to_pct:     end_pct,
+            share_pct:  (fraction * 100).round
+          }
+        end
+      %>
+      <% gradient_stops = slices.map { |s| "#{s[:color]} #{s[:from_pct]}% #{s[:to_pct]}%" }.join(", ") %>
+
+      <div class="d-flex flex-wrap align-items-center gap-4">
+        <div class="rounded-circle flex-shrink-0"
+             style="width: 180px; height: 180px; background: conic-gradient(<%= gradient_stops %>);"
+             role="img"
+             aria-label="Loss reasons breakdown">
+        </div>
+
+        <div class="flex-grow-1" style="min-width: 280px;">
+          <table class="table table-sm mb-0 align-middle">
+            <thead class="table-light">
+              <tr>
+                <th style="width: 24px;"></th>
+                <th>Reason</th>
+                <th class="text-end">Lost jobs</th>
+                <th class="text-end">Share</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% slices.each do |s| %>
+                <tr>
+                  <td>
+                    <span class="d-inline-block rounded"
+                          style="width: 14px; height: 14px; background: <%= s[:color] %>;"></span>
+                  </td>
+                  <td><%= s[:row][:display_name] %></td>
+                  <td class="text-end"><%= s[:row][:count] %></td>
+                  <td class="text-end"><%= s[:share_pct] %>%</td>
+                </tr>
+              <% end %>
+            </tbody>
+            <tfoot>
+              <tr class="text-muted small">
+                <td></td>
+                <td>Total</td>
+                <td class="text-end"><%= total %></td>
+                <td class="text-end">100%</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    <% else %>
+      <div class="text-muted">No lost jobs yet — nothing to break down.</div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/job_proposals/edit.html.erb
+++ b/app/views/job_proposals/edit.html.erb
@@ -127,9 +127,10 @@
       <div class="card-body">
         <div class="row g-3">
           <div class="col-md-6">
-            <%= f.label :loss_reason, "Loss reason", class: "form-label" %>
-            <%= f.text_field :loss_reason, class: "form-control", disabled: @campaign_in_flight,
-                  placeholder: "e.g. Price, Timing, No response" %>
+            <%= f.label :loss_reason_id, "Loss reason", class: "form-label" %>
+            <%= f.collection_select :loss_reason_id, @loss_reason_options, :id, :display_name,
+                  { include_blank: "— None —" },
+                  class: "form-select", disabled: @campaign_in_flight %>
           </div>
           <div class="col-md-12">
             <%= f.label :loss_notes, "Loss notes", class: "form-label" %>

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -119,6 +119,27 @@
   </div>
 </div>
 
+<% if @job_proposal.pipeline_stage_lost? %>
+  <div class="card shadow-sm mb-4 border-danger-subtle">
+    <div class="card-header bg-danger-subtle">
+      <h2 class="h5 mb-0">Why we lost this job</h2>
+    </div>
+    <div class="card-body">
+      <dl class="row mb-0">
+        <dt class="col-sm-3">Loss reason</dt>
+        <dd class="col-sm-9">
+          <%= @job_proposal.loss_reason&.display_name || content_tag(:span, "—", class: "text-muted") %>
+        </dd>
+
+        <dt class="col-sm-3">Loss notes</dt>
+        <dd class="col-sm-9">
+          <%= simple_format(@job_proposal.loss_notes.presence || content_tag(:span, "—", class: "text-muted").to_s) %>
+        </dd>
+      </dl>
+    </div>
+  </div>
+<% end %>
+
 <% campaign_instance = @job_proposal.campaign_instances.order(created_at: :desc).first %>
 <div class="card shadow-sm mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -314,9 +314,12 @@
               Capture why the customer didn't move forward. Both fields are required.
             </p>
             <div class="mb-3">
-              <%= label_tag :loss_reason, "Loss reason", class: "form-label" %>
-              <%= text_field_tag :loss_reason, @job_proposal.loss_reason, class: "form-control", required: true,
-                    placeholder: "e.g. Price, Timing, No response" %>
+              <%= label_tag :loss_reason_id, "Loss reason", class: "form-label" %>
+              <%= select_tag :loss_reason_id,
+                    options_from_collection_for_select(@loss_reason_options, :id, :display_name, @job_proposal.loss_reason_id),
+                    include_blank: "Select a reason",
+                    required: true,
+                    class: "form-select" %>
             </div>
             <div class="mb-0">
               <%= label_tag :loss_notes, "Loss notes", class: "form-label" %>

--- a/db/migrate/20260509101104_create_loss_reasons.rb
+++ b/db/migrate/20260509101104_create_loss_reasons.rb
@@ -1,0 +1,48 @@
+class CreateLossReasons < ActiveRecord::Migration[8.1]
+  def up
+    create_table :loss_reasons do |t|
+      t.string :code, null: false
+      t.string :display_name, null: false
+      t.integer :sort_order, null: false, default: 0
+      t.timestamps
+    end
+    add_index :loss_reasons, :code, unique: true
+
+    execute <<~SQL
+      INSERT INTO loss_reasons (code, display_name, sort_order, created_at, updated_at) VALUES
+        ('price_too_high',             'Price too high',                10, NOW(), NOW()),
+        ('went_with_competitor',       'Went with competitor',          20, NOW(), NOW()),
+        ('insurance_issue',            'Insurance issue',               30, NOW(), NOW()),
+        ('no_response_from_customer',  'No response from customer',     40, NOW(), NOW()),
+        ('timing_scheduling_conflict', 'Timing / scheduling conflict',  50, NOW(), NOW()),
+        ('other',                      'Other',                         99, NOW(), NOW());
+    SQL
+
+    add_reference :job_proposals, :loss_reason, foreign_key: true
+
+    # Best-effort backfill from the free-text column. Known seed strings
+    # map to their natural code; anything else non-blank lands on "other"
+    # so no historical context is lost outright.
+    execute <<~SQL
+      UPDATE job_proposals AS jp
+      SET loss_reason_id = lr.id
+      FROM loss_reasons AS lr
+      WHERE lr.code = CASE jp.loss_reason
+                        WHEN 'Price'       THEN 'price_too_high'
+                        WHEN 'No response' THEN 'no_response_from_customer'
+                        WHEN 'Timing'      THEN 'timing_scheduling_conflict'
+                        ELSE                    'other'
+                      END
+        AND jp.loss_reason IS NOT NULL
+        AND jp.loss_reason <> '';
+    SQL
+
+    remove_column :job_proposals, :loss_reason
+  end
+
+  def down
+    add_column :job_proposals, :loss_reason, :string
+    remove_reference :job_proposals, :loss_reason, foreign_key: true
+    drop_table :loss_reasons
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_101104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -210,7 +210,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
     t.jsonb "last_reply"
     t.bigint "location_id", null: false
     t.text "loss_notes"
-    t.string "loss_reason"
+    t.bigint "loss_reason_id"
     t.bigint "owner_id", null: false
     t.string "pipeline_stage"
     t.decimal "proposal_value", precision: 12, scale: 2
@@ -225,6 +225,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
     t.index ["dash_job_number"], name: "index_job_proposals_on_dash_job_number"
     t.index ["job_type_id"], name: "index_job_proposals_on_job_type_id"
     t.index ["location_id"], name: "index_job_proposals_on_location_id"
+    t.index ["loss_reason_id"], name: "index_job_proposals_on_loss_reason_id"
     t.index ["owner_id"], name: "index_job_proposals_on_owner_id"
     t.index ["scenario_id"], name: "index_job_proposals_on_scenario_id"
     t.index ["tenant_id"], name: "index_job_proposals_on_tenant_id"
@@ -257,6 +258,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
     t.index ["is_active"], name: "index_locations_on_is_active"
     t.index ["tenant_id"], name: "index_locations_on_tenant_id"
     t.index ["updated_by_user_id"], name: "index_locations_on_updated_by_user_id"
+  end
+
+  create_table "loss_reasons", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.string "display_name", null: false
+    t.integer "sort_order", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_loss_reasons_on_code", unique: true
   end
 
   create_table "messages", force: :cascade do |t|
@@ -417,6 +427,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_001343) do
   add_foreign_key "job_proposal_attachments", "users", column: "uploaded_by_user_id"
   add_foreign_key "job_proposals", "job_types"
   add_foreign_key "job_proposals", "locations"
+  add_foreign_key "job_proposals", "loss_reasons"
   add_foreign_key "job_proposals", "scenarios"
   add_foreign_key "job_proposals", "tenants"
   add_foreign_key "job_proposals", "users", column: "closed_by_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -102,7 +102,7 @@ DEMO_PROPOSALS = [
     house: "318", street: "Chestnut Ave", city: "Joliet", state: "IL", zip: "60435",
     value: 6_320.00, status: :closed, stage: "lost", overlay: nil,
     description: "Water heater tank failure overnight; water across utility room and into hallway. Cat 1.",
-    loss_reason: "Price",
+    loss_reason: "price_too_high",
     loss_notes: "Customer's plumber referred a competitor at lower bid; chose them after 24h." },
 
   { ref: "DEMO-WM-006", scenario: "gray_water", first: "Lacey", last: "Burke", title: "Ms.",
@@ -163,7 +163,7 @@ DEMO_PROPOSALS = [
     house: "722", street: "Woodland Heights", city: "Bloomington", state: "IL", zip: "61704",
     value: 5_980.00, status: :closed, stage: "lost", overlay: nil,
     description: "Deep clean follow-up after gray water event. Customer attempted DIY cleanup before estimate.",
-    loss_reason: "No response",
+    loss_reason: "no_response_from_customer",
     loss_notes: "Customer went silent after Day 5 follow-up; assumed self-handled." },
 
   # --- General cleaning -----------------------------------------------------
@@ -191,7 +191,7 @@ DEMO_PROPOSALS = [
     house: "16", street: "Heatherfield Court", city: "Champaign", state: "IL", zip: "61820",
     value: 2_080.00, status: :closed, stage: "lost", overlay: nil,
     description: "Estate sale prep clean before listing.",
-    loss_reason: "Timing",
+    loss_reason: "timing_scheduling_conflict",
     loss_notes: "Customer needed crew within 48 hours; we couldn't accommodate before her open-house deadline." },
 
   { ref: "DEMO-GC-006", scenario: "odor_remediation", first: "Devin", last: "Ramos", title: "Mr.",
@@ -212,6 +212,7 @@ DEMO_PROPOSALS = [
 ].freeze
 
 scenario_lookup = Scenario.includes(:job_type).index_by(&:code)
+loss_reason_lookup = LossReason.all.index_by(&:code)
 
 DEMO_PROPOSALS.each_with_index do |row, i|
   scenario = scenario_lookup[row[:scenario]]
@@ -258,7 +259,7 @@ DEMO_PROPOSALS.each_with_index do |row, i|
   if row[:status] == :closed
     proposal.closed_at = ((i % 14) + 1).days.ago
     proposal.closed_by_user = demo_owner
-    proposal.loss_reason = row[:stage] == "lost" ? row[:loss_reason] : nil
+    proposal.loss_reason = row[:stage] == "lost" ? loss_reason_lookup.fetch(row[:loss_reason]) : nil
     proposal.loss_notes = row[:stage] == "lost" ? row[:loss_notes] : nil
   else
     proposal.closed_at = nil

--- a/docs/user-guide/04-campaign-maintenance.md
+++ b/docs/user-guide/04-campaign-maintenance.md
@@ -81,7 +81,7 @@ Open the job's detail page. Two buttons sit in the top action bar next to the pa
 
 - **Mark Won** — single click. The job's pipeline stage flips to *Won* and the campaign stops if it was still running.
 - **Mark Lost** — opens a small dialog. Both fields are required:
-  - **Loss reason** — a short label (e.g. *Price*, *Timing*, *No response*).
+  - **Loss reason** — pick one from a fixed dropdown: *Price too high*, *Went with competitor*, *Insurance issue*, *No response from customer*, *Timing / scheduling conflict*, or *Other*. The fixed list keeps loss data clean enough to slice in Analytics.
   - **Loss notes** — any context worth recording about why the deal didn't move forward.
   Click **Mark Lost** in the dialog to confirm.
 

--- a/test/controllers/analytics_controller_test.rb
+++ b/test/controllers/analytics_controller_test.rb
@@ -90,4 +90,28 @@ class AnalyticsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_no_match "By location", response.body
   end
+
+  # --- Loss reasons pie ------------------------------------------------
+
+  test "Why we lost section renders a pie + reason rows when lost jobs exist" do
+    job_proposals(:in_users_org).update!(
+      pipeline_stage: :lost, loss_reason: loss_reasons(:price_too_high)
+    )
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_match "Why we lost", response.body
+    assert_match "Price too high", response.body
+    assert_select "div[role=img][aria-label=?]", "Loss reasons breakdown"
+  end
+
+  test "Why we lost shows an empty-state message when nothing is lost" do
+    JobProposal.update_all(pipeline_stage: "in_campaign", loss_reason_id: nil)
+    sign_in @user_one
+    get analytics_url
+    assert_response :success
+    assert_match "Why we lost", response.body
+    assert_match "No lost jobs yet", response.body
+    assert_select "div[role=img][aria-label=?]", "Loss reasons breakdown", count: 0
+  end
 end

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -519,7 +519,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     get edit_job_proposal_url(jp)
     assert_response :success
     assert_no_match(/Loss notes/, response.body)
-    assert_select "input[name='job_proposal[loss_reason]']", count: 0
+    assert_select "select[name='job_proposal[loss_reason_id]']", count: 0
   end
 
   test "edit shows the Loss notes section once the proposal is past drafting" do
@@ -529,7 +529,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     get edit_job_proposal_url(jp)
     assert_response :success
     assert_match(/Loss notes/, response.body)
-    assert_select "input[name='job_proposal[loss_reason]']"
+    assert_select "select[name='job_proposal[loss_reason_id]']"
   end
 
   test "edit job_type select only includes job types this tenant has activated" do
@@ -587,7 +587,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
           customer_email: "edited@example.com",
           customer_house_number: "100",
           customer_street: "Test Street",
-          loss_reason: "Price",
+          loss_reason_id: loss_reasons(:price_too_high).id,
           loss_notes: "Customer chose competitor.",
           internal_reference: "REF-123",
           owner_id: other_owner.id,
@@ -605,7 +605,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal "Edited", jp.customer_first_name
     assert_equal "edited@example.com", jp.customer_email
-    assert_equal "Price", jp.loss_reason
+    assert_equal loss_reasons(:price_too_high), jp.loss_reason
     assert_equal "Customer chose competitor.", jp.loss_notes
     assert_equal "REF-123", jp.internal_reference
     assert_equal other_owner, jp.owner
@@ -858,22 +858,32 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     jp = job_proposals(:in_users_org)
     patch mark_lost_job_proposal_url(jp), params: {
-      loss_reason: "Price",
-      loss_notes:  "Picked the lower bid."
+      loss_reason_id: loss_reasons(:price_too_high).id,
+      loss_notes:     "Picked the lower bid."
     }
     assert_redirected_to job_proposal_path(jp)
     assert_match(/lost/i, flash[:notice])
     jp.reload
     assert_equal "lost", jp.pipeline_stage
-    assert_equal "Price", jp.loss_reason
+    assert_equal loss_reasons(:price_too_high), jp.loss_reason
     assert_equal "Picked the lower bid.", jp.loss_notes
   end
 
-  test "mark_lost rejects when loss_reason is blank" do
+  test "mark_lost rejects when loss_reason_id is blank" do
     sign_in @user
     jp = job_proposals(:in_users_org)
     jp.update!(pipeline_stage: nil)
-    patch mark_lost_job_proposal_url(jp), params: { loss_reason: "", loss_notes: "Notes." }
+    patch mark_lost_job_proposal_url(jp), params: { loss_reason_id: "", loss_notes: "Notes." }
+    assert_redirected_to job_proposal_path(jp)
+    assert_match(/required/i, flash[:alert])
+    assert_nil jp.reload.pipeline_stage
+  end
+
+  test "mark_lost rejects when loss_reason_id refers to an unknown row" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: nil)
+    patch mark_lost_job_proposal_url(jp), params: { loss_reason_id: 0, loss_notes: "Notes." }
     assert_redirected_to job_proposal_path(jp)
     assert_match(/required/i, flash[:alert])
     assert_nil jp.reload.pipeline_stage
@@ -883,7 +893,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     jp = job_proposals(:in_users_org)
     jp.update!(pipeline_stage: nil)
-    patch mark_lost_job_proposal_url(jp), params: { loss_reason: "Price", loss_notes: "" }
+    patch mark_lost_job_proposal_url(jp), params: { loss_reason_id: loss_reasons(:price_too_high).id, loss_notes: "" }
     assert_redirected_to job_proposal_path(jp)
     assert_match(/required/i, flash[:alert])
     assert_nil jp.reload.pipeline_stage

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -982,6 +982,30 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", revert_pipeline_stage_job_proposal_path(jp), count: 0
   end
 
+  test "show page renders the loss-details card with reason and notes when pipeline_stage is lost" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(
+      pipeline_stage: "lost",
+      loss_reason: loss_reasons(:went_with_competitor),
+      loss_notes: "Customer chose ABC Restoration after the second visit."
+    )
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_match(/Why we lost this job/, response.body)
+    assert_match(/Went with competitor/, response.body)
+    assert_match(/Customer chose ABC Restoration/, response.body)
+  end
+
+  test "show page hides the loss-details card when pipeline_stage is not lost" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: "won")
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_no_match(/Why we lost this job/, response.body)
+  end
+
   # --- pause --------------------------------------------------------------
 
   test "pause redirects to sign-in when not signed in" do

--- a/test/fixtures/loss_reasons.yml
+++ b/test/fixtures/loss_reasons.yml
@@ -1,0 +1,29 @@
+price_too_high:
+  code: price_too_high
+  display_name: Price too high
+  sort_order: 10
+
+went_with_competitor:
+  code: went_with_competitor
+  display_name: Went with competitor
+  sort_order: 20
+
+insurance_issue:
+  code: insurance_issue
+  display_name: Insurance issue
+  sort_order: 30
+
+no_response_from_customer:
+  code: no_response_from_customer
+  display_name: No response from customer
+  sort_order: 40
+
+timing_scheduling_conflict:
+  code: timing_scheduling_conflict
+  display_name: Timing / scheduling conflict
+  sort_order: 50
+
+other:
+  code: other
+  display_name: Other
+  sort_order: 99

--- a/test/models/loss_reason_test.rb
+++ b/test/models/loss_reason_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class LossReasonTest < ActiveSupport::TestCase
+  def valid_attrs(overrides = {})
+    {
+      code: "fresh_code",
+      display_name: "Fresh Reason",
+      sort_order: 100
+    }.merge(overrides)
+  end
+
+  test "valid with required fields" do
+    assert LossReason.new(valid_attrs).valid?
+  end
+
+  test "requires code" do
+    refute LossReason.new(valid_attrs(code: nil)).valid?
+  end
+
+  test "requires display_name" do
+    refute LossReason.new(valid_attrs(display_name: nil)).valid?
+  end
+
+  test "code is unique" do
+    LossReason.create!(valid_attrs(code: "dup"))
+    refute LossReason.new(valid_attrs(code: "dup")).valid?
+  end
+
+  test "ordered scope sorts by sort_order then display_name" do
+    codes = LossReason.ordered.pluck(:code)
+    expected = %w[
+      price_too_high
+      went_with_competitor
+      insurance_issue
+      no_response_from_customer
+      timing_scheduling_conflict
+      other
+    ]
+    assert_equal expected, codes
+  end
+end

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -108,4 +108,50 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
     assert_equal [], result.conversion_rate_by_location
   end
+
+  # --- Loss reasons breakdown -------------------------------------------
+
+  test "loss_reasons_breakdown groups lost proposals by reason and orders by sort_order" do
+    JobProposal.update_all(pipeline_stage: "in_campaign", loss_reason_id: nil)
+    job_proposals(:in_users_org).update!(
+      pipeline_stage: :lost, loss_reason: loss_reasons(:price_too_high)
+    )
+    job_proposals(:same_tenant_other_org).update!(
+      pipeline_stage: :lost, loss_reason: loss_reasons(:went_with_competitor)
+    )
+    # Add a second "Price" so it leads.
+    extra = JobProposal.create!(
+      tenant: tenants(:one), location: locations(:ne_dallas),
+      owner: users(:one), created_by_user: users(:one),
+      customer_first_name: "X", customer_last_name: "Y", proposal_value: 1,
+      pipeline_stage: :lost, loss_reason: loss_reasons(:price_too_high)
+    )
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    rows = result.loss_reasons_breakdown
+    assert_equal 2, rows.size
+    assert_equal "Price too high",       rows[0][:display_name]
+    assert_equal 2,                      rows[0][:count]
+    assert_equal "Went with competitor", rows[1][:display_name]
+    assert_equal 1,                      rows[1][:count]
+
+    extra.destroy!
+  end
+
+  test "loss_reasons_breakdown buckets lost proposals with a NULL loss_reason as Unspecified" do
+    JobProposal.update_all(pipeline_stage: "in_campaign", loss_reason_id: nil)
+    job_proposals(:in_users_org).update!(pipeline_stage: :lost, loss_reason: nil)
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    rows = result.loss_reasons_breakdown
+    assert_equal 1, rows.size
+    assert_equal "Unspecified", rows[0][:display_name]
+    assert_equal 1, rows[0][:count]
+  end
+
+  test "loss_reasons_breakdown is empty when nothing is lost" do
+    JobProposal.update_all(pipeline_stage: "in_campaign", loss_reason_id: nil)
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    assert_equal [], result.loss_reasons_breakdown
+  end
 end


### PR DESCRIPTION
End-to-end work for loss tracking. Three commits, each self-contained:

## 1. \`loss_reasons\` table + FK (foundational)

The Mark Lost flow used a free-text Loss reason field, which made the data unfit for any future Analytics roll-ups. Replaced it with a real metadata table and a FK on \`job_proposals\`.

One self-contained migration (\`20260509101104_create_loss_reasons\`):

- Creates \`loss_reasons\` (\`code\`, \`display_name\`, \`sort_order\`, unique index on \`code\`).
- **Inserts the six product-defined rows inline** in the migration:
  - \`price_too_high\`, \`went_with_competitor\`, \`insurance_issue\`, \`no_response_from_customer\`, \`timing_scheduling_conflict\`, \`other\`.
- Adds \`job_proposals.loss_reason_id\` with a FK constraint.
- Best-effort backfills the existing free-text column (\`Price\` → \`price_too_high\`, \`No response\` → \`no_response_from_customer\`, \`Timing\` → \`timing_scheduling_conflict\`, anything else non-blank → \`other\`).
- Drops the old \`loss_reason\` string column.

App-side: \`LossReason\` model + \`JobProposal belongs_to :loss_reason, optional: true\`. Controllers permit \`loss_reason_id\` and load \`LossReason.ordered\` for form options. The Mark Lost modal, the operator edit form's Loss notes card, and the admin "new manual job" form all use \`<select>\`. \`mark_lost\` requires a real LossReason row, not just non-blank text.

## 2. "Why we lost this job" card on the proposal show page

When \`pipeline_stage\` is \`lost\`, surface the picked reason and the operator's notes between the Job card and the Campaign card, with a danger-tinted border. Hidden for won and in-campaign jobs.

## 3. Loss-reasons pie chart at the bottom of Analytics

\`AnalyticsCalculator\` now exposes \`loss_reasons_breakdown\` — a sort_order-ordered list of \`{ display_name, count }\` hashes scoped to the same proposals_scope as every other metric. The dashboard renders a CSS conic-gradient pie + a legend table under the existing activity chart. No JS dependency. Lost proposals with NULL \`loss_reason_id\` bucket as "Unspecified" so the slices always sum to \`lost_count\`. Empty-state copy when nothing is lost.

## User guide

§4e Mark Lost lists the six fixed labels and notes that the constrained list is what enables Analytics slicing.

## Tests

\`\`\`
715 runs, 3068 assertions, 0 failures, 0 errors, 0 skips
8 system tests, 17 assertions, 0 failures
\`\`\`

- \`LossReasonTest\` — presence + uniqueness + ordered-scope.
- \`AnalyticsCalculatorTest\` — breakdown grouping/ordering, NULL→Unspecified fallback, empty scope.
- \`JobProposalsControllerTest\` — \`mark_lost\` happy-path / blank-id / unknown-id / blank-notes; show-page renders the loss card when lost and hides it when won.
- \`AnalyticsControllerTest\` — pie + reason rows render with lost jobs; empty-state message renders without.

## Test plan

- [ ] Run \`docker-compose exec web bundle exec rails db:migrate\` on a copy of staging and verify the existing free-text values landed on the expected codes (or fell through to \`other\`).
- [ ] In the operator UI, open a job and click **Mark Lost**: dropdown shows the six labels, validation alerts on missing fields.
- [ ] Mark a job lost, then reopen it: confirm the new "Why we lost this job" card renders the picked reason + notes.
- [ ] Open Analytics with at least one lost job: confirm the pie at the bottom is colored and the legend totals match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)