### PR TITLE
admin/pdf_processing_revisions: pin current at top, show page for prior revisions

### DIFF
--- a/app/controllers/admin/pdf_processing_revisions_controller.rb
+++ b/app/controllers/admin/pdf_processing_revisions_controller.rb
@@ -1,6 +1,17 @@
 class Admin::PdfProcessingRevisionsController < Admin::BaseController
   def index
-    @revisions = PdfProcessingRevision.includes(:model).order(revision_number: :desc)
+    @current = PdfProcessingRevision.includes(:model).is_current
+    # The index page renders the current revision in full at the top,
+    # so exclude it from the "Previous revisions" table to avoid showing
+    # the same row twice.
+    @previous_revisions = PdfProcessingRevision
+      .includes(:model)
+      .where.not(id: @current&.id)
+      .order(revision_number: :desc)
+  end
+
+  def show
+    @revision = PdfProcessingRevision.includes(:model).find(params[:id])
     @current = PdfProcessingRevision.is_current
   end
 

--- a/app/views/admin/pdf_processing_revisions/index.html.erb
+++ b/app/views/admin/pdf_processing_revisions/index.html.erb
@@ -5,9 +5,39 @@
   <%= link_to "New revision", new_admin_pdf_processing_revision_path, class: "btn btn-primary btn-sm" %>
 </div>
 
+<%# --- Current revision --------------------------------------------------- %>
+<div class="card shadow-sm mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <div class="d-flex align-items-center gap-2">
+      <h2 class="h5 mb-0">Current instructions</h2>
+      <% if @current %>
+        <span class="badge text-bg-success">Revision #<%= @current.revision_number %></span>
+      <% end %>
+    </div>
+    <% if @current %>
+      <span class="text-muted small">
+        <%= @current.model.name %> · created <%= l(@current.created_at, format: :short) %>
+      </span>
+    <% end %>
+  </div>
+  <div class="card-body">
+    <% if @current %>
+      <pre class="mb-0" style="white-space: pre-wrap;"><%= @current.instructions %></pre>
+    <% else %>
+      <div class="text-center text-muted">
+        No revisions yet. <%= link_to "Create the first one", new_admin_pdf_processing_revision_path %>.
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%# --- Previous revisions ------------------------------------------------- %>
 <div class="card shadow-sm">
+  <div class="card-header">
+    <h2 class="h5 mb-0">Previous revisions</h2>
+  </div>
   <div class="card-body p-0">
-    <% if @revisions.any? %>
+    <% if @previous_revisions.any? %>
       <table class="table mb-0 align-middle">
         <thead class="table-light">
           <tr>
@@ -15,27 +45,25 @@
             <th>Instructions</th>
             <th>Model</th>
             <th>Created</th>
-            <th></th>
+            <th class="text-end" style="width: 1%;"></th>
           </tr>
         </thead>
         <tbody>
-          <% @revisions.each do |r| %>
+          <% @previous_revisions.each do |r| %>
             <tr>
               <td class="text-end fw-semibold"><%= r.revision_number %></td>
               <td><%= truncate(r.instructions, length: 200) %></td>
               <td><%= r.model.name %></td>
               <td><%= l(r.created_at, format: :short) %></td>
-              <td>
-                <% if r == @current %>
-                  <span class="badge text-bg-success">Current</span>
-                <% end %>
+              <td class="text-end">
+                <%= link_to "View", admin_pdf_processing_revision_path(r), class: "btn btn-sm btn-outline-primary" %>
               </td>
             </tr>
           <% end %>
         </tbody>
       </table>
     <% else %>
-      <div class="p-4 text-center text-muted">No revisions yet.</div>
+      <div class="p-4 text-center text-muted">No previous revisions.</div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/pdf_processing_revisions/show.html.erb
+++ b/app/views/admin/pdf_processing_revisions/show.html.erb
@@ -1,0 +1,42 @@
+<% content_for :title, "Revision ##{@revision.revision_number}" %>
+
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb mb-0">
+    <li class="breadcrumb-item"><%= link_to "PDF Processing Revisions", admin_pdf_processing_revisions_path %></li>
+    <li class="breadcrumb-item active" aria-current="page">Revision #<%= @revision.revision_number %></li>
+  </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-center gap-2">
+    <h1 class="h3 mb-0">Revision #<%= @revision.revision_number %></h1>
+    <% if @revision == @current %>
+      <span class="badge text-bg-success">Current</span>
+    <% end %>
+  </div>
+  <%= link_to "Back to revisions", admin_pdf_processing_revisions_path, class: "btn btn-sm btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Model</dt>
+      <dd class="col-sm-9">
+        <%= @revision.model.name %>
+        <span class="text-muted small"><%= @revision.model.provider %></span>
+      </dd>
+
+      <dt class="col-sm-3">Created</dt>
+      <dd class="col-sm-9"><%= l(@revision.created_at, format: :long) %></dd>
+    </dl>
+  </div>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-header">
+    <h2 class="h5 mb-0">Instructions</h2>
+  </div>
+  <div class="card-body">
+    <pre class="mb-0" style="white-space: pre-wrap;"><%= @revision.instructions %></pre>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
     resources :messages, only: [:index]
     resources :tool_calls, only: [:index]
     resources :models, only: [:index]
-    resources :pdf_processing_revisions, only: [:index, :new, :create]
+    resources :pdf_processing_revisions, only: [:index, :show, :new, :create]
     resource :application_mailbox, only: [:show, :destroy], controller: "application_mailbox"
     resources :integrations, only: [:index] do
       collection { post :check }

--- a/test/controllers/admin/pdf_processing_revisions_controller_test.rb
+++ b/test/controllers/admin/pdf_processing_revisions_controller_test.rb
@@ -27,18 +27,65 @@ class Admin::PdfProcessingRevisionsControllerTest < ActionDispatch::IntegrationT
     assert_match "No revisions yet.", response.body
   end
 
-  test "admin index lists revisions newest first and badges the current one" do
-    PdfProcessingRevision.create!(instructions: "v1", model: @model)
+  test "admin index pins the current revision at the top in full and lists older revisions in the table below" do
+    older   = PdfProcessingRevision.create!(instructions: "v1", model: @model)
     current = PdfProcessingRevision.create!(instructions: "v2", model: @model)
     sign_in @admin
 
     get admin_pdf_processing_revisions_url
     assert_response :success
+    assert_match "Current instructions", response.body
+    assert_match "Previous revisions",   response.body
     assert_match "v2", response.body
     assert_match "v1", response.body
-    assert_match "Current", response.body
-    assert response.body.index("v2") < response.body.index("v1"), "v2 should appear before v1"
+    # Current's full body sits in the top card; the table only links to older.
+    assert response.body.index("Current instructions") < response.body.index("Previous revisions"),
+           "Current section should appear before Previous"
+    assert_select "a[href=?]", admin_pdf_processing_revision_path(older), text: "View"
     assert_equal current, PdfProcessingRevision.is_current
+  end
+
+  test "admin index empty-state shows when there are no previous revisions, even with one current" do
+    PdfProcessingRevision.create!(instructions: "only", model: @model)
+    sign_in @admin
+    get admin_pdf_processing_revisions_url
+    assert_response :success
+    assert_match "only", response.body
+    assert_match "No previous revisions.", response.body
+  end
+
+  # --- show ---------------------------------------------------------------
+
+  test "show redirects to sign-in when not signed in" do
+    rev = PdfProcessingRevision.create!(instructions: "x", model: @model)
+    get admin_pdf_processing_revision_url(rev)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "non-admin cannot reach show" do
+    rev = PdfProcessingRevision.create!(instructions: "x", model: @model)
+    sign_in @non_admin
+    get admin_pdf_processing_revision_url(rev)
+    assert_redirected_to root_path
+  end
+
+  test "admin show renders the revision number, model, and instructions" do
+    rev = PdfProcessingRevision.create!(instructions: "Detailed steps for extraction.", model: @model)
+    sign_in @admin
+    get admin_pdf_processing_revision_url(rev)
+    assert_response :success
+    assert_match "Revision ##{rev.revision_number}", response.body
+    assert_match @model.name, response.body
+    assert_match "Detailed steps for extraction.", response.body
+  end
+
+  test "admin show flags the current revision with a Current badge" do
+    PdfProcessingRevision.create!(instructions: "older", model: @model)
+    current = PdfProcessingRevision.create!(instructions: "newer", model: @model)
+    sign_in @admin
+    get admin_pdf_processing_revision_url(current)
+    assert_response :success
+    assert_match "Current", response.body
   end
 
   test "admin sees the new form" do


### PR DESCRIPTION
**Stacked on top of #179 (feature/sentry).** Rebase or change the base to \`main\` once #179 merges.

The index page used to render every revision in one truncated table (200-char preview per row), which made the live extraction prompt hard to read at a glance. This PR splits it into two cards and adds a per-revision show page so older prompts can be inspected in full.

## Changes

- **Index** — top card pins the active revision with the **full** instructions in a \`<pre>\` block, plus model + created-at meta in the header. The current row is hidden from the table below.
- **Previous revisions** table — every older revision in a row, with a **View** button linking to the new show page. Empty-state copy when nothing is older than the current.
- **Show page** — revision number, model + provider, created-at timestamp, and the full instructions in a \`<pre>\` block. Flips on a \`Current\` badge if you happen to land there for the active revision (e.g. via a deep link from the table).
- **Routes** — \`Admin::PdfProcessingRevisions\` resources gains \`:show\`.

## Tests

\`738 runs, 3178 assertions, 0 failures\` (5 new assertions for the new behavior; the existing index-order test was rewritten for the split layout).

- Index split: current pinned, older linked, no-previous empty state.
- Show: auth gates (redirect to sign-in / root for non-admin), content rendered (revision #, model name, instructions), Current badge on the active revision.

## Test plan

- [ ] Open **Platform Admin → Job Prompt** — confirm the current instructions render in full at the top, and the table below lists older revisions newest-first.
- [ ] Click **View** on an older revision — confirm the show page renders the full prompt and the breadcrumb back to the index works.
- [ ] Confirm the **New revision** affordance still works (no regression on the create path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)