### PR TITLE
Platform Admin: cross-tenant Users index

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,21 @@
 class Admin::UsersController < Admin::BaseController
   EDITABLE_PARAMS = %i[first_name last_name title phone_number location_id].freeze
 
-  before_action :load_tenant
-  before_action :load_user
+  before_action :load_tenant, except: [:index]
+  before_action :load_user, except: [:index]
+
+  def index
+    scope = User.includes(:tenant, :location, :email_delegations).order(:email)
+
+    @tenant_options = Tenant.order(:name)
+    @selected_tenant_id = params[:tenant_id].presence
+    @search = params[:q].to_s.strip
+
+    scope = scope.where(tenant_id: @selected_tenant_id) if @selected_tenant_id
+    scope = apply_search(scope, @search) if @search.present?
+
+    @users = scope
+  end
 
   def edit
     @location_options = @tenant.locations.active.order(:display_name)
@@ -48,5 +61,17 @@ class Admin::UsersController < Admin::BaseController
 
   def audit_snapshot(user)
     user.slice(:first_name, :last_name, :title, :phone_number, :location_id)
+  end
+
+  # Free-text search across email, first name, and last name. Compose with
+  # `concat_ws` so a "first last" query matches a user with both fields
+  # populated as well as a single-token query against either.
+  def apply_search(scope, query)
+    pattern = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+    scope.where(
+      "users.email ILIKE :p OR users.first_name ILIKE :p OR users.last_name ILIKE :p OR " \
+      "concat_ws(' ', users.first_name, users.last_name) ILIKE :p",
+      p: pattern
+    )
   end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,115 @@
+<% content_for :title, "Users" %>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div class="d-flex align-items-baseline gap-2">
+    <h1 class="h3 mb-0">Users</h1>
+    <span class="text-muted small"><%= pluralize(@users.size, "user") %></span>
+  </div>
+</div>
+
+<%= form_with url: admin_users_path, method: :get, local: true, class: "card shadow-sm mb-3" do |f| %>
+  <div class="card-body py-3">
+    <div class="row g-2 align-items-end">
+      <div class="col-sm-5">
+        <%= label_tag :q, "Search", class: "form-label small mb-1" %>
+        <%= text_field_tag :q, @search,
+              placeholder: "Email or name",
+              class: "form-control form-control-sm" %>
+      </div>
+      <div class="col-sm-4">
+        <%= label_tag :tenant_id, "Tenant", class: "form-label small mb-1" %>
+        <%= select_tag :tenant_id,
+              options_from_collection_for_select(@tenant_options, :id, :name, @selected_tenant_id),
+              include_blank: "All tenants",
+              class: "form-select form-select-sm" %>
+      </div>
+      <div class="col-sm-3 d-flex gap-2">
+        <%= f.submit "Filter", class: "btn btn-primary btn-sm" %>
+        <% if @selected_tenant_id || @search.present? %>
+          <%= link_to "Clear", admin_users_path, class: "btn btn-outline-secondary btn-sm" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="card shadow-sm">
+  <div class="card-body p-0">
+    <% if @users.any? %>
+      <table class="table mb-0 align-middle">
+        <thead class="table-light">
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Tenant</th>
+            <th>Location</th>
+            <th>Role</th>
+            <th>Gmail</th>
+            <th class="text-end">Status</th>
+            <th class="text-end" style="width: 1%;"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @users.each do |user| %>
+            <tr>
+              <td>
+                <% if user.full_name.present? %>
+                  <%= user.full_name %>
+                <% else %>
+                  <span class="text-muted">—</span>
+                <% end %>
+              </td>
+              <td><%= user.email %></td>
+              <td>
+                <% if user.tenant %>
+                  <%= link_to user.tenant.name, admin_tenant_path(user.tenant) %>
+                <% else %>
+                  <span class="text-muted">—</span>
+                <% end %>
+              </td>
+              <td>
+                <% if user.location %>
+                  <%= user.location.display_name %>
+                <% else %>
+                  <span class="text-muted">—</span>
+                <% end %>
+              </td>
+              <td>
+                <% if user.is_admin %>
+                  <span class="badge text-bg-dark">Application Admin</span>
+                <% elsif user.is_tenant_admin? %>
+                  <span class="badge text-bg-info">Tenant Admin</span>
+                <% else %>
+                  <span class="badge text-bg-secondary">Originator</span>
+                <% end %>
+              </td>
+              <td>
+                <% gmail_delegation = user.email_delegations.find { |d| d.provider == "google" } %>
+                <% if gmail_delegation %>
+                  <span class="badge text-bg-success">Linked</span>
+                  <div class="text-muted small"><%= gmail_delegation.email %></div>
+                <% else %>
+                  <span class="text-muted small">Not linked</span>
+                <% end %>
+              </td>
+              <td class="text-end">
+                <% if user.is_pending %>
+                  <span class="badge text-bg-warning">Pending</span>
+                <% else %>
+                  <span class="badge text-bg-success">Active</span>
+                <% end %>
+              </td>
+              <td class="text-end">
+                <% if user.tenant %>
+                  <%= link_to "Edit", edit_admin_tenant_user_path(user.tenant, user), class: "btn btn-sm btn-outline-primary" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="p-4 text-center text-muted">No users match these filters.</div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -16,6 +16,7 @@
       <h6 class="text-uppercase text-muted small mt-3 mb-1 px-3">Platform Admin</h6>
       <%= link_to "Analytics", admin_analytics_path, class: "nav-link #{'active' if controller_path == 'admin/analytics'}" %>
       <%= link_to "Tenant / Account", admin_tenants_path, class: "nav-link #{'active' if controller_name == 'tenants'}" %>
+      <%= link_to "Users", admin_users_path, class: "nav-link #{'active' if controller_path == 'admin/users'}" %>
       <%= link_to "Job Types", admin_job_types_path, class: "nav-link #{'active' if controller_path == 'admin/job_types'}" %>
       <%= link_to "Campaigns", admin_campaigns_path, class: "nav-link #{'active' if controller_name == 'campaigns'}" %>
       <%= link_to "Mailbox", admin_application_mailbox_path, class: "nav-link #{'active' if controller_path == 'admin/application_mailbox'}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       end
       resources :scenario_activations, only: [:create, :destroy]
     end
+    resources :users, only: [:index]
     resources :job_types do
       resources :scenarios, only: [:new, :create]
     end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -90,4 +90,67 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href=?]", edit_admin_tenant_user_path(@tenant, @teammate), text: "Edit"
   end
+
+  # --- index --------------------------------------------------------------
+
+  test "index redirects to sign-in when not signed in" do
+    get admin_users_url
+    assert_redirected_to new_user_session_path
+  end
+
+  test "non-admin cannot reach the cross-tenant users index" do
+    sign_in @non_admin
+    get admin_users_url
+    assert_redirected_to root_path
+  end
+
+  test "admin index lists users from every tenant" do
+    sign_in @admin
+    get admin_users_url
+    assert_response :success
+    assert_match users(:one).email,   response.body  # tenant: one
+    assert_match users(:two).email,   response.body  # tenant: two
+    assert_match @teammate.email,     response.body  # created in setup, tenant: one
+  end
+
+  test "tenant filter narrows the index to that tenant's users" do
+    sign_in @admin
+    get admin_users_url, params: { tenant_id: tenants(:two).id }
+    assert_response :success
+    assert_match users(:two).email,    response.body
+    assert_no_match users(:one).email, response.body
+    assert_no_match @teammate.email,   response.body
+  end
+
+  test "search query matches by email substring" do
+    sign_in @admin
+    get admin_users_url, params: { q: "admin-edit-victim" }
+    assert_response :success
+    assert_match @teammate.email,      response.body
+    assert_no_match users(:one).email, response.body
+  end
+
+  test "search query matches by full name" do
+    @teammate.update!(first_name: "Pat", last_name: "Sample")
+    sign_in @admin
+    get admin_users_url, params: { q: "pat sample" }
+    assert_response :success
+    assert_match @teammate.email,      response.body
+    assert_no_match users(:one).email, response.body
+  end
+
+  test "index renders an Edit link routed through the user's tenant" do
+    sign_in @admin
+    get admin_users_url
+    assert_response :success
+    assert_select "a[href=?]", edit_admin_tenant_user_path(@tenant, @teammate), text: "Edit"
+  end
+
+  test "index shows a Tenant Admin badge for users with a tenant and no location" do
+    @teammate.update!(tenant: @tenant, location: nil)
+    sign_in @admin
+    get admin_users_url
+    assert_response :success
+    assert_select "tr", text: /#{@teammate.email}.*Tenant Admin/m
+  end
 end


### PR DESCRIPTION
Each tenant's show page already lists its users, but there's no flat view of every user across the install. Add one under **Platform Admin**.

## Changes

- **Sidebar** — new \`Users\` link under Platform Admin, between \`Tenant / Account\` and \`Job Types\`.
- **Route** — top-level \`resources :users, only: [:index]\` under the \`admin\` namespace, alongside the existing per-tenant \`users\` edit/update routes (which stay where they were).
- **Controller** — \`Admin::UsersController#index\` (the same controller that handles per-tenant edit/update; \`load_tenant\` and \`load_user\` are now \`except: [:index]\`). Eager-loads \`:tenant\`, \`:location\`, and \`:email_delegations\`. Supports a **tenant** filter and a free-text **search** across \`email\`, \`first_name\`, \`last_name\`, and \`concat_ws(' ', first_name, last_name)\` so a "first last" query matches.
- **View** — Name, Email, Tenant (linked to its admin show page), Location, Role badge (\`Application Admin\` / \`Tenant Admin\` / \`Originator\`), Gmail linked-or-not, Status, and an **Edit** button routed through \`/admin/tenants/:tenant_id/users/:id/edit\` so the existing audit-logged edit path keeps doing the work.

## Tests

\`746 runs, 3214 assertions, 0 failures\` (8 new assertions for the new behavior).

- Auth gates: redirects to sign-in for guests, root for non-admin.
- Cross-tenant listing surfaces users from every tenant.
- Tenant filter narrows to one tenant.
- Search matches email substring and full-name substring.
- Edit link routes through the user's tenant.
- Role badge correctly identifies a tenant admin (no location, has tenant).

## Test plan

- [ ] Open **Platform Admin → Users** — confirm every user across every tenant lists.
- [ ] Use the tenant dropdown to scope; confirm the count and rows update.
- [ ] Type a name or email fragment; confirm the search narrows.
- [ ] Click **Edit** on a row — confirm it lands on the tenant-scoped edit form (audit logging path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)