### PR TITLE
sidebar: scope Team active state to the non-admin UsersController only

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     <%= link_to "Jobs", job_proposals_path, class: "nav-link #{'active' if controller_name == 'job_proposals' && params[:filter] != 'needs_attention'}" %>
     <%= link_to "Analytics", analytics_path, class: "nav-link #{'active' if controller_path == 'analytics'}" %>
-    <%= link_to "Team", users_path, class: "nav-link #{'active' if controller_name == 'users'}" %>
+    <%= link_to "Team", users_path, class: "nav-link #{'active' if controller_path == 'users'}" %>
 
     <% if current_user.is_admin %>
       <h6 class="text-uppercase text-muted small mt-3 mb-1 px-3">Platform Admin</h6>


### PR DESCRIPTION
controller_name returns "users" for both UsersController and Admin::UsersController, so the new /admin/users index lit up Team in addition to the Platform Admin Users link. Switch to controller_path, which is namespaced ("users" vs "admin/users") and disambiguates them.