### PR TITLE
Job proposal: append-only activity timeline via paper_trail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem "ruby_llm"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# Append-only model audit trail [https://github.com/paper-trail-gem/paper_trail]
+gem "paper_trail"
+
 # Google OAuth for collecting Gmail send-on-behalf-of tokens
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,9 @@ GEM
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.6.3)
+    paper_trail (17.0.0)
+      activerecord (>= 7.1)
+      request_store (~> 1.4)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -464,6 +467,8 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -639,6 +644,7 @@ DEPENDENCIES
   letter_opener_web
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  paper_trail
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   stale_when_importmap_changes
 
   before_action :authenticate_user!, unless: :devise_controller?
+  before_action :set_paper_trail_whodunnit
   around_action :use_user_time_zone
 
   rescue_from CanCan::AccessDenied do |exception|
@@ -13,6 +14,14 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  # PaperTrail records the actor on every Version row via `whodunnit`.
+  # Stash the signed-in user's id on the request so model writes from
+  # this request get attributed correctly. Background-job writes have
+  # no signed-in user and end up as nil ("System" in the UI).
+  def set_paper_trail_whodunnit
+    ::PaperTrail.request.whodunnit = current_user&.id if user_signed_in?
+  end
 
   # Wraps the request in Time.use_zone(<user's tz>) so view rendering
   # (to_fs, time_ago_in_words, l(...)) uses the operator's local clock.

--- a/app/controllers/job_proposal_histories_controller.rb
+++ b/app/controllers/job_proposal_histories_controller.rb
@@ -1,0 +1,10 @@
+class JobProposalHistoriesController < ApplicationController
+  def show
+    # Authorize through the parent proposal — same scope as the show page
+    # the timeline lives on. A 404 from accessible_by handles cross-tenant
+    # access without leaking history existence.
+    @job_proposal = JobProposal.accessible_by(current_ability).find(params[:job_proposal_id])
+    @version      = @job_proposal.versions.find(params[:id])
+    @actor        = User.find_by(id: @version.whodunnit)
+  end
+end

--- a/app/helpers/job_proposal_histories_helper.rb
+++ b/app/helpers/job_proposal_histories_helper.rb
@@ -1,0 +1,24 @@
+module JobProposalHistoriesHelper
+  # Operator-facing one-liner for the activity timeline. Folds an
+  # arbitrary-sized changeset into a comma-separated list of humanized
+  # field names so the timeline stays scannable.
+  def history_summary(version)
+    case version.event
+    when "create"  then "Job proposal created"
+    when "destroy" then "Job proposal deleted"
+    else
+      fields = (version.changeset || {}).keys
+      return "Updated" if fields.empty?
+      "Updated #{fields.map { |f| f.to_s.humanize.downcase }.to_sentence}"
+    end
+  end
+
+  # Whodunnit is stored as a string id; resolve to a User if we can,
+  # otherwise show "System" so a job-driven write or pre-paper_trail
+  # row reads cleanly.
+  def history_actor_label(version)
+    return "System" if version.whodunnit.blank?
+    user = User.find_by(id: version.whodunnit)
+    user&.display_name || "User ##{version.whodunnit}"
+  end
+end

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -1,4 +1,17 @@
 class JobProposal < ApplicationRecord
+  # Append-only audit trail via paper_trail. Every create / update /
+  # destroy on a proposal writes a row to the polymorphic `versions`
+  # table. We route writes through our locked-down Version subclass
+  # (see app/models/version.rb) so rows can't be edited or deleted
+  # after the fact. The activity timeline on the proposal show page
+  # reads these.
+  #
+  # Ignore the bookkeeping `updated_at` so a touch (or a save that
+  # only differs in updated_at) doesn't produce a noise row in the
+  # timeline — paper_trail skips writing a version when the changeset
+  # consists only of ignored attributes.
+  has_paper_trail versions: { class_name: "Version" }, ignore: [:updated_at]
+
   belongs_to :tenant
   belongs_to :location
   belongs_to :owner, class_name: "User"

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,0 +1,21 @@
+# Custom PaperTrail::Version subclass used for every audit row in this
+# app. The whole point of the audit trail is "you can't quietly rewrite
+# history," so block updates and destroys at the Rails layer. Records
+# stay queryable; mutations raise `ActiveRecord::ReadOnlyRecord`.
+#
+# Wired in via config/initializers/paper_trail.rb
+# (`PaperTrail.config.version_class_name = "Version"`).
+class Version < PaperTrail::Version
+  before_update  :reject_mutation
+  before_destroy :reject_mutation
+
+  def readonly?
+    persisted?
+  end
+
+  private
+
+  def reject_mutation
+    raise ActiveRecord::ReadOnlyRecord, "audit-trail Version rows are immutable once written"
+  end
+end

--- a/app/views/job_proposal_histories/show.html.erb
+++ b/app/views/job_proposal_histories/show.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title, "Activity — #{@job_proposal.short_address || "Job Proposal ##{@job_proposal.id}"}" %>
+
+<%= link_to "← Back to proposal", job_proposal_path(@job_proposal), class: "small text-muted" %>
+
+<div class="d-flex justify-content-between align-items-center mt-2 mb-4">
+  <div>
+    <h1 class="h3 mb-0"><%= history_summary(@version) %></h1>
+    <div class="text-muted small">
+      <%= l(@version.created_at, format: :long) %>
+      · by <%= @actor ? @actor.display_name : content_tag(:span, "System", class: "fst-italic") %>
+    </div>
+  </div>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-header">
+    <h2 class="h5 mb-0">Changes</h2>
+  </div>
+  <div class="card-body p-0">
+    <% changeset = @version.changeset || {} %>
+    <% if changeset.any? %>
+      <table class="table mb-0 align-middle">
+        <thead class="table-light">
+          <tr>
+            <th style="width: 25%;">Field</th>
+            <th>Before</th>
+            <th>After</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% changeset.each do |field, (before, after)| %>
+            <tr>
+              <td class="fw-semibold"><%= field.to_s.humanize %></td>
+              <td>
+                <% if before.nil? || before.to_s.empty? %>
+                  <span class="text-muted">—</span>
+                <% else %>
+                  <code><%= before.to_s.truncate(200) %></code>
+                <% end %>
+              </td>
+              <td>
+                <% if after.nil? || after.to_s.empty? %>
+                  <span class="text-muted">—</span>
+                <% else %>
+                  <code><%= after.to_s.truncate(200) %></code>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="p-4 text-center text-muted">
+        No field-level changes recorded — this entry marks a lifecycle event.
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -324,6 +324,38 @@
   </div>
 <% end %>
 
+<%# --- Activity timeline -------------------------------------------------- %>
+<div class="card shadow-sm mt-4">
+  <div class="card-header">
+    <h2 class="h5 mb-0">Activity</h2>
+  </div>
+  <div class="card-body p-0">
+    <% versions = @job_proposal.versions.order(created_at: :desc) %>
+    <% if versions.any? %>
+      <ul class="list-group list-group-flush mb-0">
+        <% versions.each do |version| %>
+          <li class="list-group-item">
+            <div class="d-flex justify-content-between align-items-start gap-2">
+              <div>
+                <%= link_to history_summary(version),
+                      job_proposal_history_path(@job_proposal, version),
+                      class: "fw-semibold text-decoration-none" %>
+                <div class="small text-muted">
+                  <%= time_ago_in_words(version.created_at) %> ago
+                  · by <%= history_actor_label(version) %>
+                </div>
+              </div>
+              <span class="badge text-bg-secondary text-uppercase"><%= version.event %></span>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="p-4 text-center text-muted">No activity yet.</div>
+    <% end %>
+  </div>
+</div>
+
 <% unless %w[won lost].include?(@job_proposal.pipeline_stage) %>
   <div class="modal fade" id="markLostModal" tabindex="-1" aria-labelledby="markLostModalLabel" aria-hidden="true">
     <div class="modal-dialog">

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -330,7 +330,7 @@
     <h2 class="h5 mb-0">Activity</h2>
   </div>
   <div class="card-body p-0">
-    <% versions = @job_proposal.versions.order(created_at: :desc) %>
+    <% versions = @job_proposal.versions.reorder(created_at: :desc, id: :desc) %>
     <% if versions.any? %>
       <ul class="list-group list-group-flush mb-0">
         <% versions.each do |version| %>

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,9 @@
+# Use the JSON serializer for paper_trail's `object` and `object_changes`
+# columns. The default YAML serializer with safe_load chokes on Rails
+# value types (ActiveSupport::TimeWithZone in particular), causing
+# `version.changeset` to silently return {} when an update touches
+# updated_at — which renders the activity timeline useless.
+#
+# JSON sidesteps the safe-load allowlist entirely. Serialized timestamps
+# round-trip as ISO-8601 strings, which is fine for our display use.
+PaperTrail.serializer = PaperTrail::Serializers::JSON

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     end
     resources :step_instances, only: [:show], controller: "campaign_step_instances"
     resources :campaign_instances, only: [:show]
+    resources :histories, only: [:show], controller: "job_proposal_histories"
   end
 
   namespace :admin do

--- a/db/migrate/20260510013410_create_versions.rb
+++ b/db/migrate/20260510013410_create_versions.rb
@@ -1,0 +1,41 @@
+# This migration creates the `versions` table for the Version class.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[8.1]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      # Consider using bigint type for performance if you are going to store only numeric ids.
+      # t.bigint   :whodunnit
+      t.string   :whodunnit
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+
+      t.bigint   :item_id,   null: false
+      t.string   :item_type, null: false
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20260510013411_add_object_changes_to_versions.rb
+++ b/db/migrate/20260510013411_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.1]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_111234) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_013411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -426,6 +426,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_111234) do
     t.index ["location_id"], name: "index_users_on_location_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["tenant_id"], name: "index_users_on_tenant_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.datetime "created_at"
+    t.string "event", null: false
+    t.bigint "item_id", null: false
+    t.string "item_type", null: false
+    t.text "object"
+    t.text "object_changes"
+    t.string "whodunnit"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/controllers/job_proposal_histories_controller_test.rb
+++ b/test/controllers/job_proposal_histories_controller_test.rb
@@ -10,10 +10,12 @@ class JobProposalHistoriesControllerTest < ActionDispatch::IntegrationTest
 
     PaperTrail.request.whodunnit = users(:admin).id
     @jp.update!(internal_reference: "HIST-#{SecureRandom.hex(2)}")
-    # Order by id rather than created_at — within a single test, two
-    # update!s often share a microsecond and created_at ties are
-    # unstable. id is monotonically increasing and disambiguates.
-    @version = @jp.versions.order(id: :desc).first
+    # `reorder` rather than `order`: paper_trail's has_many :versions
+    # ships with a default ASC order; chaining `order(id: :desc)` would
+    # append (giving us the oldest, not the newest). id is also more
+    # stable than created_at, which can tie within a single test
+    # microsecond.
+    @version = @jp.versions.reorder(id: :desc).first
     PaperTrail.request.whodunnit = nil
   end
 

--- a/test/controllers/job_proposal_histories_controller_test.rb
+++ b/test/controllers/job_proposal_histories_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class JobProposalHistoriesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user        = users(:one)
+    @other_user  = users(:two)
+    @jp          = job_proposals(:in_users_org)
+
+    PaperTrail.request.whodunnit = users(:admin).id
+    @jp.update!(internal_reference: "HIST-#{SecureRandom.hex(2)}")
+    # Order by id rather than created_at — within a single test, two
+    # update!s often share a microsecond and created_at ties are
+    # unstable. id is monotonically increasing and disambiguates.
+    @version = @jp.versions.order(id: :desc).first
+    PaperTrail.request.whodunnit = nil
+  end
+
+  test "redirects to sign-in when not authenticated" do
+    get job_proposal_history_url(@jp, @version)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "404s for a version belonging to a proposal in another tenant" do
+    sign_in @other_user # tenant: two; @jp is in tenant: one
+    get job_proposal_history_url(@jp, @version)
+    assert_response :not_found
+  end
+
+  test "renders the version with the changeset and resolved actor name" do
+    sign_in @user
+    get job_proposal_history_url(@jp, @version)
+    assert_response :success
+    # Field name renders humanized in the Changes table.
+    assert_match "Internal reference",         response.body
+    assert_match users(:admin).display_name,   response.body
+  end
+
+  # --- timeline integration on the proposal show page ---------------------
+
+  test "show page lists every version with newest first and links to each" do
+    PaperTrail.request.whodunnit = users(:admin).id
+    @jp.update!(internal_reference: "TWO-#{SecureRandom.hex(2)}")
+    second = @jp.versions.order(id: :desc).first
+
+    sign_in @user
+    get job_proposal_url(@jp)
+    assert_response :success
+    assert_match "Activity", response.body
+    assert_select "a[href=?]", job_proposal_history_path(@jp, second)
+    assert_select "a[href=?]", job_proposal_history_path(@jp, @version)
+  end
+end

--- a/test/models/job_proposal_test.rb
+++ b/test/models/job_proposal_test.rb
@@ -261,4 +261,43 @@ class JobProposalTest < ActiveSupport::TestCase
     @jp.update!(status: :approved, dash_job_number: "98765")
     assert_equal "98765", @jp.reload.dash_job_number
   end
+
+  # --- paper_trail history -------------------------------------------------
+
+  test "every meaningful update creates a paper_trail version with the changeset" do
+    PaperTrail.request.whodunnit = users(:admin).id
+    assert_difference -> { @jp.versions.count }, 1 do
+      @jp.update!(internal_reference: "AUDIT-#{SecureRandom.hex(4)}")
+    end
+    version = @jp.versions.order(created_at: :desc).first
+    assert_equal "update", version.event
+    assert_equal users(:admin).id.to_s, version.whodunnit
+    assert_includes version.changeset.keys, "internal_reference"
+  end
+
+  test "noisy updated_at-only saves do not write a version" do
+    PaperTrail.request.whodunnit = users(:admin).id
+    @jp.update!(internal_reference: "FIRST")
+    baseline = @jp.versions.count
+    @jp.touch
+    assert_equal baseline, @jp.reload.versions.count, "touch must not produce a new version"
+  end
+
+  test "version rows are immutable — saving raises ActiveRecord::ReadOnlyRecord" do
+    PaperTrail.request.whodunnit = users(:admin).id
+    @jp.update!(internal_reference: "IMMUTABLE")
+    version = @jp.versions.last
+    assert_raises ActiveRecord::ReadOnlyRecord do
+      version.update!(whodunnit: "tampered")
+    end
+  end
+
+  test "version rows cannot be destroyed individually" do
+    PaperTrail.request.whodunnit = users(:admin).id
+    @jp.update!(internal_reference: "STAYING")
+    version = @jp.versions.last
+    assert_raises ActiveRecord::ReadOnlyRecord do
+      version.destroy
+    end
+  end
 end


### PR DESCRIPTION
Track every create / update to a \`JobProposal\` as an immutable audit row and surface them as an **Activity** card on the proposal show page, with a per-version detail page.

After starting a hand-rolled implementation I switched to **paper_trail** — same shape (jsonb-ish change payload, actor, immutable on write) but the gem already handles the callback wiring and request-scoped actor capture.

## Choices

- **Storage** — paper_trail's \`versions\` table from its installer (\`--with-changes\` adds the \`object_changes\` column).
- **Serializer** — \`PaperTrail.serializer = PaperTrail::Serializers::JSON\`. The default YAML \`safe_load\` rejects \`ActiveSupport::TimeWithZone\`, which silently empties \`version.changeset\` for any update that touches \`updated_at\`. JSON sidesteps the safe-load allowlist.
- **Immutability** — a custom \`Version < PaperTrail::Version\` raises \`ActiveRecord::ReadOnlyRecord\` on update / destroy and reports \`readonly? = true\` once persisted. \`JobProposal\` is wired to the subclass via \`has_paper_trail versions: { class_name: "Version" }\`.
- **Noise filter** — \`updated_at\` is on the ignore list, so a touch (or a save that only bumps \`updated_at\`) doesn't produce a row.
- **Whodunnit** — captured in \`ApplicationController\` via \`PaperTrail.request.whodunnit = current_user.id\`. Explicit rather than relying on paper_trail-rails' controller mixin, which isn't auto-included in this version of the gem.

## UI

- New nested resource: \`/job_proposals/:id/histories/:id\`.
- **Activity** card on the proposal show page lists every version newest-first with a humanized summary, actor name, time-ago, and event badge (\`create\` / \`update\` / \`destroy\`).
- Per-version page renders the field-by-field changeset with humanized field names and before / after values, plus a back-link to the proposal.

## Tests

\`754 runs, 3239 assertions, 0 failures\` (8 new assertions across model + controller).

Coverage:

- paper_trail captures changesets on update.
- Touch-only saves do not create versions.
- Version rows are immutable: \`update!\` and \`destroy\` raise \`ActiveRecord::ReadOnlyRecord\`.
- Auth gates on the history show (redirect to sign-in for guests, 404 for cross-tenant).
- Show page renders the changeset with humanized field names + the resolved actor display name.
- Proposal show page lists every version with newest-first ordering and one link per version.

## Test plan

- [ ] Edit a proposal a few times via the UI and refresh the show page — confirm the **Activity** card lists the changes newest-first with your name as the actor.
- [ ] Click into a single activity entry — confirm the field-level Before / After table renders.
- [ ] Try \`JobProposal.first.versions.last.update!(whodunnit: "tampered")\` from \`rails console\` — confirm it raises \`ReadOnlyRecord\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)