### PR TITLE
Scenario: add authoring_hypothesis text field

### DIFF
--- a/app/controllers/admin/scenarios_controller.rb
+++ b/app/controllers/admin/scenarios_controller.rb
@@ -47,6 +47,6 @@ class Admin::ScenariosController < Admin::BaseController
   end
 
   def scenario_params
-    params.require(:scenario).permit(:code, :short_name, :description, :campaign_id)
+    params.require(:scenario).permit(:code, :short_name, :description, :authoring_hypothesis, :campaign_id)
   end
 end

--- a/app/views/admin/scenarios/_form.html.erb
+++ b/app/views/admin/scenarios/_form.html.erb
@@ -35,6 +35,13 @@
   </div>
 
   <div class="mb-3">
+    <%= f.label :authoring_hypothesis, "Authoring hypothesis", class: "form-label" %>
+    <%= f.text_area :authoring_hypothesis, rows: 6, class: "form-control",
+          placeholder: "What we believe is true about this customer/situation, and what the cadence is leveraging on. The why behind the templated content." %>
+    <div class="form-text">Internal — captures the operator-side rationale for the scenario's content. Not shown to customers.</div>
+  </div>
+
+  <div class="mb-3">
     <%= f.label :campaign_id, "Campaign", class: "form-label" %>
     <% if @scenario.persisted? %>
       <% scoped_campaigns = @scenario.attributed_campaigns.order(:name) %>

--- a/app/views/admin/scenarios/show.html.erb
+++ b/app/views/admin/scenarios/show.html.erb
@@ -26,6 +26,9 @@
       <dt class="col-sm-3">Description</dt>
       <dd class="col-sm-9"><%= simple_format(@scenario.description.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
 
+      <dt class="col-sm-3">Authoring hypothesis</dt>
+      <dd class="col-sm-9"><%= simple_format(@scenario.authoring_hypothesis.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
+
       <dt class="col-sm-3">Job type</dt>
       <dd class="col-sm-9"><%= link_to @job_type.name, admin_job_type_path(@job_type) %></dd>
 

--- a/db/migrate/20260509222919_add_authoring_hypothesis_to_scenarios.rb
+++ b/db/migrate/20260509222919_add_authoring_hypothesis_to_scenarios.rb
@@ -1,0 +1,8 @@
+class AddAuthoringHypothesisToScenarios < ActiveRecord::Migration[8.1]
+  def change
+    # Free-form text — sample copy in SPEC-11 / authoring docs runs ~100
+    # words, but the field is intentionally open-ended for the operator
+    # to capture the why behind a scenario's templated content.
+    add_column :scenarios, :authoring_hypothesis, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -344,6 +344,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_013411) do
   end
 
   create_table "scenarios", force: :cascade do |t|
+    t.text "authoring_hypothesis"
     t.bigint "campaign_id"
     t.string "code", limit: 64, null: false
     t.datetime "created_at", null: false

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -117,6 +117,41 @@ class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
+  # --- authoring_hypothesis ---
+
+  test "edit form exposes the authoring hypothesis textarea" do
+    sign_in @admin
+    get edit_admin_scenario_url(@scenario)
+    assert_response :success
+    assert_select "form textarea[name='scenario[authoring_hypothesis]']"
+  end
+
+  test "update saves the authoring hypothesis" do
+    sign_in @admin
+    hypothesis = "Variant assumes move-in / move-out customers convert on logistical confidence."
+    patch admin_scenario_url(@scenario), params: { scenario: { authoring_hypothesis: hypothesis } }
+    assert_redirected_to admin_scenario_path(@scenario)
+    assert_equal hypothesis, @scenario.reload.authoring_hypothesis
+  end
+
+  test "show renders the authoring hypothesis when set" do
+    @scenario.update!(authoring_hypothesis: "We believe X about this customer.")
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_match "Authoring hypothesis", response.body
+    assert_match "We believe X about this customer.", response.body
+  end
+
+  test "show falls back to em-dash when authoring hypothesis is blank" do
+    @scenario.update!(authoring_hypothesis: nil)
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_match "Authoring hypothesis", response.body
+    assert_select "dt", text: "Authoring hypothesis"
+  end
+
   # --- destroy ---
 
   test "destroy removes the scenario and returns to the job type page" do


### PR DESCRIPTION
The hypothesis is the operator-side rationale behind a scenario's templated content — what we believe is true about the customer or situation, and what the cadence is leveraging on. Captured here so the why behind the copy lives next to the scenario, not in a separate doc that drifts. Closes one of the SPEC-11 §11 / 2026-05-10 PRD-SPEC assessment §22 #6 residuals.

## Changes

- **Migration** — \`scenarios.authoring_hypothesis\` (\`text\`, nullable). Free-form to allow the ~100-word rationale the spec illustrates.
- **Form** — textarea (6 rows) between Description and Campaign with placeholder copy and a \"Internal — not shown to customers\" form-text.
- **Show page** — rendered between Description and Job type via \`simple_format\` so paragraph breaks survive; em-dash fallback when blank.
- **Controller** — added to the permit list in \`scenario_params\`.

## Tests

\`758 runs, 3256 assertions, 0 failures\` (4 new assertions for the new field).

- Edit form exposes the textarea.
- Update persists the value.
- Show renders the saved hypothesis.
- Show keeps the row visible (with em-dash) when the hypothesis is blank.

## Test plan

- [ ] Open **Platform Admin → Job Types → \<job type\> → \<scenario\> → Edit**, paste the example hypothesis, save, confirm it round-trips.
- [ ] Confirm the field renders on the scenario show page with paragraph breaks intact.
- [ ] Confirm a scenario without a hypothesis shows the em-dash placeholder rather than disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)