### PR TITLE
Scenario: add industry_classification string field

### DIFF
--- a/app/controllers/admin/scenarios_controller.rb
+++ b/app/controllers/admin/scenarios_controller.rb
@@ -47,6 +47,6 @@ class Admin::ScenariosController < Admin::BaseController
   end
 
   def scenario_params
-    params.require(:scenario).permit(:code, :short_name, :description, :campaign_id)
+    params.require(:scenario).permit(:code, :short_name, :description, :industry_classification, :campaign_id)
   end
 end

--- a/app/views/admin/scenarios/_form.html.erb
+++ b/app/views/admin/scenarios/_form.html.erb
@@ -35,6 +35,13 @@
   </div>
 
   <div class="mb-3">
+    <%= f.label :industry_classification, "Industry classification", class: "form-label" %>
+    <%= f.text_field :industry_classification, class: "form-control",
+          placeholder: "e.g. IICRC S520 Mold Remediation" %>
+    <div class="form-text">Free-form. The standard or category this scenario fits under.</div>
+  </div>
+
+  <div class="mb-3">
     <%= f.label :campaign_id, "Campaign", class: "form-label" %>
     <% if @scenario.persisted? %>
       <% scoped_campaigns = @scenario.attributed_campaigns.order(:name) %>

--- a/app/views/admin/scenarios/show.html.erb
+++ b/app/views/admin/scenarios/show.html.erb
@@ -26,6 +26,9 @@
       <dt class="col-sm-3">Authoring hypothesis</dt>
       <dd class="col-sm-9"><%= simple_format(@scenario.description.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
 
+      <dt class="col-sm-3">Industry classification</dt>
+      <dd class="col-sm-9"><%= @scenario.industry_classification.presence || content_tag(:span, "—", class: "text-muted") %></dd>
+
       <dt class="col-sm-3">Job type</dt>
       <dd class="col-sm-9"><%= link_to @job_type.name, admin_job_type_path(@job_type) %></dd>
 

--- a/db/migrate/20260510024000_add_industry_classification_to_scenarios.rb
+++ b/db/migrate/20260510024000_add_industry_classification_to_scenarios.rb
@@ -1,0 +1,9 @@
+class AddIndustryClassificationToScenarios < ActiveRecord::Migration[8.1]
+  def change
+    # Free-form string for industry / standards classification (e.g.
+    # "IICRC S520 Mold Remediation"). Intentionally not an enum — the
+    # taxonomy is wide and per-scenario; operators paste the code/name
+    # they want surfaced.
+    add_column :scenarios, :industry_classification, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_023927) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_024000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -348,6 +348,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_023927) do
     t.string "code", limit: 64, null: false
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "industry_classification"
     t.bigint "job_type_id", null: false
     t.string "short_name", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -138,6 +138,40 @@ class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
     assert_select "dt", text: "Description", count: 0
   end
 
+  # --- industry_classification ---
+
+  test "edit form exposes the industry classification text field" do
+    sign_in @admin
+    get edit_admin_scenario_url(@scenario)
+    assert_response :success
+    assert_select "form input[type=text][name='scenario[industry_classification]']"
+  end
+
+  test "update saves the industry classification" do
+    sign_in @admin
+    patch admin_scenario_url(@scenario),
+      params: { scenario: { industry_classification: "IICRC S520 Mold Remediation" } }
+    assert_redirected_to admin_scenario_path(@scenario)
+    assert_equal "IICRC S520 Mold Remediation", @scenario.reload.industry_classification
+  end
+
+  test "show renders the industry classification when set" do
+    @scenario.update!(industry_classification: "IICRC S520 Mold Remediation")
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_match "Industry classification", response.body
+    assert_match "IICRC S520 Mold Remediation", response.body
+  end
+
+  test "show keeps the industry-classification row visible with em-dash when blank" do
+    @scenario.update!(industry_classification: nil)
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_select "dt", text: "Industry classification"
+  end
+
   # --- destroy ---
 
   test "destroy removes the scenario and returns to the job type page" do


### PR DESCRIPTION
Free-form classification on \`Scenario\` so operators can pin the standard or category a scenario fits under (e.g. \`IICRC S520 Mold Remediation\`). Intentionally not an enum — the taxonomy is wide and per-scenario.

Closes the SPEC-03 §13.2 residual flagged in the [2026-05-10 PRD/SPEC assessment](docs/progress_reports/2026-05-10_PRD_SPEC_assessment.md). Pairs with #184 (authoring_hypothesis) which closes the SPEC-11 §11 sibling.

## Changes

- **Migration** — \`scenarios.industry_classification\` (\`string\`, nullable).
- **Form** — \`text_field\` between Description and Campaign with the example placeholder.
- **Show page** — rendered between Description and Job type with an em-dash fallback when blank.
- **Controller** — added to the permit list in \`scenario_params\`.

## Tests

\`758 runs, 3254 assertions, 0 failures\` (4 new assertions for the new field).

- Edit form exposes the text field.
- Update persists the value.
- Show renders the saved classification.
- Show keeps the row visible (with em-dash) when the classification is blank.

## Test plan

- [ ] Open **Platform Admin → Job Types → \<job type\> → \<scenario\> → Edit**, type \`IICRC S520 Mold Remediation\`, save, confirm it round-trips.
- [ ] Confirm the field renders on the scenario show page.
- [ ] Confirm a scenario without a classification shows the em-dash placeholder rather than disappearing.

## Coordination with #184

Both PRs touch the same \`Admin::ScenariosController#scenario_params\` permit list, the same \`_form.html.erb\`, and the same \`show.html.erb\`. Whichever merges first will produce a tiny three-way merge against the other — straightforward (each adds a single line in the same regions). I'll rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)