### PR TITLE
Scenarios: revert authoring_hypothesis column, relabel description as Authoring hypothesis

### DIFF
--- a/app/controllers/admin/scenarios_controller.rb
+++ b/app/controllers/admin/scenarios_controller.rb
@@ -47,6 +47,6 @@ class Admin::ScenariosController < Admin::BaseController
   end
 
   def scenario_params
-    params.require(:scenario).permit(:code, :short_name, :description, :authoring_hypothesis, :campaign_id)
+    params.require(:scenario).permit(:code, :short_name, :description, :campaign_id)
   end
 end

--- a/app/views/admin/scenarios/_form.html.erb
+++ b/app/views/admin/scenarios/_form.html.erb
@@ -30,15 +30,8 @@
   </div>
 
   <div class="mb-3">
-    <%= f.label :description, class: "form-label" %>
+    <%= f.label :description, "Authoring hypothesis", class: "form-label" %>
     <%= f.text_area :description, rows: 3, class: "form-control" %>
-  </div>
-
-  <div class="mb-3">
-    <%= f.label :authoring_hypothesis, "Authoring hypothesis", class: "form-label" %>
-    <%= f.text_area :authoring_hypothesis, rows: 6, class: "form-control",
-          placeholder: "What we believe is true about this customer/situation, and what the cadence is leveraging on. The why behind the templated content." %>
-    <div class="form-text">Internal — captures the operator-side rationale for the scenario's content. Not shown to customers.</div>
   </div>
 
   <div class="mb-3">

--- a/app/views/admin/scenarios/show.html.erb
+++ b/app/views/admin/scenarios/show.html.erb
@@ -23,11 +23,8 @@
       <dt class="col-sm-3">Short name</dt>
       <dd class="col-sm-9"><%= @scenario.short_name %></dd>
 
-      <dt class="col-sm-3">Description</dt>
-      <dd class="col-sm-9"><%= simple_format(@scenario.description.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
-
       <dt class="col-sm-3">Authoring hypothesis</dt>
-      <dd class="col-sm-9"><%= simple_format(@scenario.authoring_hypothesis.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
+      <dd class="col-sm-9"><%= simple_format(@scenario.description.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
 
       <dt class="col-sm-3">Job type</dt>
       <dd class="col-sm-9"><%= link_to @job_type.name, admin_job_type_path(@job_type) %></dd>

--- a/db/migrate/20260510023927_remove_authoring_hypothesis_from_scenarios.rb
+++ b/db/migrate/20260510023927_remove_authoring_hypothesis_from_scenarios.rb
@@ -1,0 +1,8 @@
+class RemoveAuthoringHypothesisFromScenarios < ActiveRecord::Migration[8.1]
+  # Walk back the column added in 20260509222919. The product decision is
+  # to relabel the existing `description` field as "Authoring hypothesis"
+  # in the UI rather than carry two near-duplicate text columns.
+  def change
+    remove_column :scenarios, :authoring_hypothesis, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_013411) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_023927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -344,7 +344,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_013411) do
   end
 
   create_table "scenarios", force: :cascade do |t|
-    t.text "authoring_hypothesis"
     t.bigint "campaign_id"
     t.string "code", limit: 64, null: false
     t.datetime "created_at", null: false

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -117,39 +117,25 @@ class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
-  # --- authoring_hypothesis ---
+  # --- Authoring hypothesis label (the description field, relabeled in the UI) ---
 
-  test "edit form exposes the authoring hypothesis textarea" do
+  test "edit form labels the description field as Authoring hypothesis" do
     sign_in @admin
     get edit_admin_scenario_url(@scenario)
     assert_response :success
-    assert_select "form textarea[name='scenario[authoring_hypothesis]']"
+    assert_select "form label[for='scenario_description']", text: "Authoring hypothesis"
+    assert_select "form textarea[name='scenario[description]']"
   end
 
-  test "update saves the authoring hypothesis" do
-    sign_in @admin
-    hypothesis = "Variant assumes move-in / move-out customers convert on logistical confidence."
-    patch admin_scenario_url(@scenario), params: { scenario: { authoring_hypothesis: hypothesis } }
-    assert_redirected_to admin_scenario_path(@scenario)
-    assert_equal hypothesis, @scenario.reload.authoring_hypothesis
-  end
-
-  test "show renders the authoring hypothesis when set" do
-    @scenario.update!(authoring_hypothesis: "We believe X about this customer.")
+  test "show page surfaces the description under the Authoring hypothesis label" do
+    @scenario.update!(description: "Variant assumes customers convert on logistical confidence.")
     sign_in @admin
     get admin_scenario_url(@scenario)
     assert_response :success
-    assert_match "Authoring hypothesis", response.body
-    assert_match "We believe X about this customer.", response.body
-  end
-
-  test "show falls back to em-dash when authoring hypothesis is blank" do
-    @scenario.update!(authoring_hypothesis: nil)
-    sign_in @admin
-    get admin_scenario_url(@scenario)
-    assert_response :success
-    assert_match "Authoring hypothesis", response.body
     assert_select "dt", text: "Authoring hypothesis"
+    assert_match "Variant assumes customers convert on logistical confidence.", response.body
+    # The old "Description" label must be gone.
+    assert_select "dt", text: "Description", count: 0
   end
 
   # --- destroy ---


### PR DESCRIPTION
Replaces #184. Product decision: \"the existing description field IS the hypothesis\" rather than carrying two near-duplicate text columns. Walk back the column and rename the existing label end-to-end.

## Changes

- **Migration** — drops \`scenarios.authoring_hypothesis\`. Timestamp \`20260510023927\` is after the schema.rb baseline so a clean \`db:drop / db:schema:load / db:migrate\` runs the removal cleanly without the schema-loader auto-marking it as already applied.
- **Form** — \`f.label :description, \"Authoring hypothesis\", ...\` so the rendered \`<label>\` reads \"Authoring hypothesis\" while the column stays as \`description\`.
- **Show** — \`<dt>\` renamed \`Description\` → \`Authoring hypothesis\` above the same \`simple_format\`-rendered body.
- **Controller** — drop \`authoring_hypothesis\` from the permit list; the existing \`description\` entry is what we keep.
- **Tests** — drop the four \`authoring_hypothesis\` assertions added in #184; replace with two on the renamed label (form + show, plus a guard that the old \`Description\` dt is gone).

Net: one column, one label, no schema churn going forward.

## Tests

\`756 runs, 3250 assertions, 0 failures\`.

## Test plan

- [ ] Open **Platform Admin → Job Types → \<job type\> → \<scenario\> → Edit**, confirm the textarea is now labeled \"Authoring hypothesis\".
- [ ] Save text and confirm it persists (still in the \`description\` column under the hood).
- [ ] On the show page, confirm the \"Description\" dt is gone and \"Authoring hypothesis\" surfaces the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)