### PR TITLE
Scenarios: industry_classification + analytics Closed Revenue MTD/YTD

### DIFF
--- a/app/controllers/admin/scenarios_controller.rb
+++ b/app/controllers/admin/scenarios_controller.rb
@@ -47,6 +47,6 @@ class Admin::ScenariosController < Admin::BaseController
   end
 
   def scenario_params
-    params.require(:scenario).permit(:code, :short_name, :description, :campaign_id)
+    params.require(:scenario).permit(:code, :short_name, :description, :industry_classification, :campaign_id)
   end
 end

--- a/app/services/analytics_calculator.rb
+++ b/app/services/analytics_calculator.rb
@@ -64,6 +64,13 @@ class AnalyticsCalculator
     conversion_rate_mtd_pct = mtd_activated.positive? ? ((mtd_won.to_f / mtd_activated) * 100).round : nil
     conversion_rate_ytd_pct = ytd_activated.positive? ? ((ytd_won.to_f / ytd_activated) * 100).round : nil
 
+    # MTD/YTD revenue uses the same closed_at bucketing as the conversion
+    # rate above so the two tiles tell a consistent story for the same
+    # window. `closed_at` is stamped on the proposal when pipeline_stage
+    # flips to :won or :lost, so it's a stable cohort marker.
+    closed_revenue_mtd = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", mtd_start).sum(:proposal_value)
+    closed_revenue_ytd = @proposals.where(pipeline_stage: :won).where("closed_at >= ?", ytd_start).sum(:proposal_value)
+
     # SPEC-06 v1.0 — per-location Conversion Rate breakdown for the
     # tile expand-toggle. Computed from the same proposals_scope so it
     # respects whatever filter the caller applied. Empty array means
@@ -144,6 +151,8 @@ class AnalyticsCalculator
       conversion_rate_ytd_pct:  conversion_rate_ytd_pct,
       conversion_rate_by_location: by_location,
       closed_revenue:           closed_revenue,
+      closed_revenue_mtd:       closed_revenue_mtd,
+      closed_revenue_ytd:       closed_revenue_ytd,
       active_pipeline_value:    active_pipeline_value,
       follow_ups_sent:          follow_ups_sent,
       originators:              originators,

--- a/app/views/admin/scenarios/_form.html.erb
+++ b/app/views/admin/scenarios/_form.html.erb
@@ -35,6 +35,13 @@
   </div>
 
   <div class="mb-3">
+    <%= f.label :industry_classification, "Industry classification", class: "form-label" %>
+    <%= f.text_field :industry_classification, class: "form-control",
+          placeholder: "e.g. IICRC S520 Mold Remediation" %>
+    <div class="form-text">Free-form. The standard or category this scenario fits under.</div>
+  </div>
+
+  <div class="mb-3">
     <%= f.label :campaign_id, "Campaign", class: "form-label" %>
     <% if @scenario.persisted? %>
       <% scoped_campaigns = @scenario.attributed_campaigns.order(:name) %>

--- a/app/views/admin/scenarios/show.html.erb
+++ b/app/views/admin/scenarios/show.html.erb
@@ -26,6 +26,9 @@
       <dt class="col-sm-3">Authoring hypothesis</dt>
       <dd class="col-sm-9"><%= simple_format(@scenario.description.presence || content_tag(:span, "—", class: "text-muted").to_s) %></dd>
 
+      <dt class="col-sm-3">Industry classification</dt>
+      <dd class="col-sm-9"><%= @scenario.industry_classification.presence || content_tag(:span, "—", class: "text-muted") %></dd>
+
       <dt class="col-sm-3">Job type</dt>
       <dd class="col-sm-9"><%= link_to @job_type.name, admin_job_type_path(@job_type) %></dd>
 

--- a/app/views/analytics/_dashboard.html.erb
+++ b/app/views/analytics/_dashboard.html.erb
@@ -75,6 +75,21 @@
       <div class="card-body">
         <div class="text-muted text-uppercase small mb-1">Closed revenue</div>
         <div class="h4 fw-semibold mb-1"><%= number_to_currency(analytics.closed_revenue, precision: 0) %></div>
+        <%# MTD / YTD inline, mirroring the Conversion Rate tile pattern. %>
+        <div class="d-flex gap-3 small mt-2 mb-2">
+          <div>
+            <span class="text-muted">MTD</span>
+            <span class="fw-semibold ms-1">
+              <%= number_to_currency(analytics.closed_revenue_mtd, precision: 0) %>
+            </span>
+          </div>
+          <div>
+            <span class="text-muted">YTD</span>
+            <span class="fw-semibold ms-1">
+              <%= number_to_currency(analytics.closed_revenue_ytd, precision: 0) %>
+            </span>
+          </div>
+        </div>
         <div class="small text-muted">Proposal value of won jobs</div>
       </div>
     </div>

--- a/db/migrate/20260510024000_add_industry_classification_to_scenarios.rb
+++ b/db/migrate/20260510024000_add_industry_classification_to_scenarios.rb
@@ -1,0 +1,9 @@
+class AddIndustryClassificationToScenarios < ActiveRecord::Migration[8.1]
+  def change
+    # Free-form string for industry / standards classification (e.g.
+    # "IICRC S520 Mold Remediation"). Intentionally not an enum — the
+    # taxonomy is wide and per-scenario; operators paste the code/name
+    # they want surfaced.
+    add_column :scenarios, :industry_classification, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_023927) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_024000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -348,6 +348,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_023927) do
     t.string "code", limit: 64, null: false
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "industry_classification"
     t.bigint "job_type_id", null: false
     t.string "short_name", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -138,6 +138,40 @@ class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
     assert_select "dt", text: "Description", count: 0
   end
 
+  # --- industry_classification ---
+
+  test "edit form exposes the industry classification text field" do
+    sign_in @admin
+    get edit_admin_scenario_url(@scenario)
+    assert_response :success
+    assert_select "form input[type=text][name='scenario[industry_classification]']"
+  end
+
+  test "update saves the industry classification" do
+    sign_in @admin
+    patch admin_scenario_url(@scenario),
+      params: { scenario: { industry_classification: "IICRC S520 Mold Remediation" } }
+    assert_redirected_to admin_scenario_path(@scenario)
+    assert_equal "IICRC S520 Mold Remediation", @scenario.reload.industry_classification
+  end
+
+  test "show renders the industry classification when set" do
+    @scenario.update!(industry_classification: "IICRC S520 Mold Remediation")
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_match "Industry classification", response.body
+    assert_match "IICRC S520 Mold Remediation", response.body
+  end
+
+  test "show keeps the industry-classification row visible with em-dash when blank" do
+    @scenario.update!(industry_classification: nil)
+    sign_in @admin
+    get admin_scenario_url(@scenario)
+    assert_response :success
+    assert_select "dt", text: "Industry classification"
+  end
+
   # --- destroy ---
 
   test "destroy removes the scenario and returns to the job type page" do

--- a/test/services/analytics_calculator_test.rb
+++ b/test/services/analytics_calculator_test.rb
@@ -81,6 +81,43 @@ class AnalyticsCalculatorTest < ActiveSupport::TestCase
     assert_nil result.conversion_rate_ytd_pct
   end
 
+  # --- Closed revenue MTD/YTD ------------------------------------------
+
+  test "closed_revenue_mtd sums won proposal_value with closed_at this month" do
+    job_proposals(:in_users_org).update!(
+      pipeline_stage: :won,
+      closed_at: Time.current.beginning_of_month + 1.hour,
+      proposal_value: 5_000
+    )
+    # Won earlier in the year — counts toward YTD but not MTD.
+    job_proposals(:same_tenant_other_org).update!(
+      pipeline_stage: :won,
+      closed_at: Time.current.beginning_of_year + 1.day,
+      proposal_value: 8_000
+    )
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    assert_equal 5_000.to_d,  result.closed_revenue_mtd
+    assert_equal 13_000.to_d, result.closed_revenue_ytd
+  end
+
+  test "closed_revenue_mtd/ytd ignore wins from prior years" do
+    last_year_close = Time.current.beginning_of_year - 1.day
+    job_proposals(:in_users_org).update!(
+      pipeline_stage: :won, closed_at: last_year_close, proposal_value: 12_345
+    )
+
+    result = AnalyticsCalculator.new(proposals_scope: tenants(:one).job_proposals).call
+    assert_equal 0.to_d, result.closed_revenue_mtd
+    assert_equal 0.to_d, result.closed_revenue_ytd
+  end
+
+  test "closed_revenue_mtd/ytd are zero when scope has nothing won" do
+    result = AnalyticsCalculator.new(proposals_scope: JobProposal.none).call
+    assert_equal 0.to_d, result.closed_revenue_mtd
+    assert_equal 0.to_d, result.closed_revenue_ytd
+  end
+
   # --- SPEC-06 v1.0 by-location breakdown -------------------------------
 
   test "conversion_rate_by_location returns one row per location with activated/won/rate" do


### PR DESCRIPTION
**Why a new PR.** PR #185 was retargeted to base on #186's branch so it could merge after the relabel landed. But #185 ended up merging into the relabel branch *after* #186 had already merged into \`main\`, which left industry_classification stranded on a branch that nothing else picked up. Reopening with \`main\` as the base brings that work onto main, plus a small follow-on (Closed Revenue MTD/YTD).

## What's in this PR

### Commit 1 — \`scenarios: add industry_classification string field\` (originally PR #185)

Free-form classification on \`Scenario\` (\`scenarios.industry_classification\` string, nullable). Operators paste the standard / category a scenario fits under (e.g. \`IICRC S520 Mold Remediation\`). Form input + show row + permit-list update + tests. Migration timestamp \`20260510024000\` so \`db:schema:load + db:migrate\` runs the add cleanly.

### Commit 2 — \`analytics: MTD and YTD on the Closed Revenue tile\`

Mirrors the SPEC-05-style MTD/YTD inline display already on the Conversion Rate tile.

- \`AnalyticsCalculator\` exposes \`closed_revenue_mtd\` and \`closed_revenue_ytd\` — \`SUM(proposal_value) WHERE pipeline_stage = won AND closed_at >= mtd_start / ytd_start\`. Same \`closed_at\` bucketing as the conversion-rate tile so the two metrics tell a consistent story for the same window.
- Closed Revenue tile renders MTD / YTD currency values inline below the all-time number, matching the Conversion Rate tile's layout.
- Tests cover this-month-only, year-to-date excluding prior-year wins, and the empty-scope zero case.

## Tests

\`759 runs, 3256 assertions, 0 failures\`.

## Test plan

- [ ] Open **Analytics** — confirm Closed Revenue tile shows MTD / YTD inline.
- [ ] Set a won proposal's \`closed_at\` earlier this month, refresh — confirm MTD reflects it.
- [ ] Open **Platform Admin → Job Types → \<job type\> → \<scenario\>** — confirm the Industry classification field renders on the form and show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)