### PR TITLE
gmail: route every customer send through one PreSendChecklist

### DIFF
--- a/app/jobs/campaign_sweep_job.rb
+++ b/app/jobs/campaign_sweep_job.rb
@@ -1,43 +1,46 @@
 require "net/http"
 
 # Runs every 5 minutes (see config/sidekiq_cron.yml) to find campaign step
-# instances whose planned_delivery_at has passed, render and send their email
-# via the application's connected Gmail mailbox, and update both the step
-# instance and its parent campaign instance to reflect the outcome.
+# instances whose planned_delivery_at has passed and either ship them via the
+# connected Gmail mailbox or block them — whichever the PreSendChecklist says.
 #
-# Eligibility: only step instances whose parent CampaignInstance is `active`,
-# whose Campaign is `approved`, and whose host JobProposal has status
-# `approved` are considered. The JobProposal status gate is the operator's
-# explicit "go" signal — until they click Approve on the campaign instance
-# page, the proposal sits in `approving` and the sweep skips it.
+# The checklist (app/services/pre_send_checklist.rb, modeled on PRD-09 v1.3
+# §9.2) is the single source of truth for what must hold before a real
+# customer email leaves the system. Both this job and the operator UI on
+# the proposal page run through the same checklist function so what the
+# operator sees is exactly what the sweep will evaluate next.
 #
-# Concurrency: each due step instance is claimed by atomically transitioning
-# its email_delivery_status from `pending` to `sending` with a conditional
-# UPDATE. If two sweeps overlap, only one gets the row.
+# Failure handling, per the checklist's failure class:
+# - :block_silent          — step stays pending, the next sweep re-evaluates.
+# - :block_delivery_issue  — step is marked failed and the campaign run is
+#                            stopped with stopped_on_delivery_issue.
 #
-# Failure handling: a delivery failure (Gmail rejection, missing recipient,
-# unsupported host, unresolved merge field) marks the step `failed` and
-# stops the parent campaign instance with `stopped_on_delivery_issue`. A
-# successful final step transitions the instance to `completed`.
+# The dev and FAKE-SEND modes never hit Gmail and therefore bypass the
+# checklist — they are local-development conveniences that route to
+# letter_opener_web or do nothing.
 class CampaignSweepJob < ApplicationJob
   queue_as :default
 
-  # Outbound mail flow goes through several gates:
+  # Send-mode resolution for a given run:
   #
-  #   1. development                                  -> route through CampaignStepMailer
-  #                                                      (Action Mailer + letter_opener_web).
+  #   1. development                                  -> :dev_letter_opener (route through
+  #                                                      CampaignStepMailer + letter_opener_web).
   #                                                      Mailbox state is irrelevant in dev;
   #                                                      we never want real Gmail traffic.
-  #   2. production AND no TEST_TO_EMAIL              -> real send to host.customer_email
-  #   3. TEST_TO_EMAIL set (any env, mailbox present) -> mail redirected to TEST_TO_EMAIL
-  #   4. non-prod AND no mailbox                      -> FAKE-SEND mode: render the email,
+  #                                                      Checklist bypassed.
+  #   2. mailbox + (production OR TEST_TO_EMAIL)      -> :real_send. Checklist runs.
+  #   3. no mailbox + non-prod                        -> :fake_send. Render the email,
   #                                                      log it, mark the step :sent.
-  #                                                      Lets test exercise the campaign
-  #                                                      lifecycle without real Gmail.
-  #   5. non-dev AND no mailbox AND non-prod          -> see #4
-  #   6. prod AND no mailbox                          -> skip; log warning
-  #   7. non-prod AND mailbox AND no TEST_TO_EMAIL    -> skip; we won't email customers
-  #                                                      from staging by accident
+  #                                                      Checklist bypassed — lets tests
+  #                                                      exercise the campaign lifecycle
+  #                                                      without real Gmail.
+  #   4. no mailbox + prod                            -> :real_send. The checklist's
+  #                                                      mailbox check surfaces every
+  #                                                      pending step as a delivery_issue
+  #                                                      so the operator sees the outage.
+  #   5. mailbox + non-prod + no TEST_TO_EMAIL        -> :skip. Staging guardrail; we
+  #                                                      will not relay through a real
+  #                                                      Gmail mailbox by accident.
   #
   # Devise mailers (password reset, registration) are unaffected — they go
   # through Action Mailer, not this job.
@@ -56,54 +59,82 @@ class CampaignSweepJob < ApplicationJob
 
   def perform
     mailbox = ApplicationMailbox.current
+    mode = resolve_mode(mailbox)
+    return if mode == :skip
 
-    if self.class.development_environment?
-      # Dev always routes through Action Mailer → letter_opener_web. We
-      # never want a connected dev mailbox to actually relay to a real
-      # customer, even if one is configured.
-      Rails.logger.info "[CampaignSweepJob] dev mode: routing campaign step sends through Action Mailer (letter_opener_web at /letter_opener)"
-    elsif mailbox
-      # Real-send path: still gate non-prod behind TEST_TO_EMAIL so we
-      # don't accidentally email customers from a staging box.
-      unless self.class.production_environment? || self.class.test_to_email_override
-        Rails.logger.warn "[CampaignSweepJob] sending disabled in #{Rails.env}; set TEST_TO_EMAIL to redirect mail, or run in production"
-        return
-      end
-    elsif !self.class.production_environment?
-      # No mailbox + non-prod env (test/staging) — fake-send so the
-      # campaign lifecycle logic is still exercised end to end.
-      Rails.logger.info "[CampaignSweepJob] no application mailbox connected; running in FAKE-SEND mode (no real email leaves the host)"
-    else
-      Rails.logger.warn "[CampaignSweepJob] no application mailbox connected; skipping sweep"
-      return
-    end
-
-    due_step_instance_ids(Time.current).each { |id| process(id, mailbox) }
+    due_step_instance_ids(Time.current).each { |id| process(id, mailbox, mode) }
   end
 
   private
+
+  def resolve_mode(mailbox)
+    if self.class.development_environment?
+      Rails.logger.info "[CampaignSweepJob] dev mode: routing campaign step sends through Action Mailer (letter_opener_web at /letter_opener)"
+      :dev_letter_opener
+    elsif mailbox && (self.class.production_environment? || self.class.test_to_email_override)
+      :real_send
+    elsif mailbox.nil? && !self.class.production_environment?
+      Rails.logger.info "[CampaignSweepJob] no application mailbox connected; running in FAKE-SEND mode (no real email leaves the host)"
+      :fake_send
+    elsif mailbox.nil? && self.class.production_environment?
+      Rails.logger.warn "[CampaignSweepJob] no application mailbox connected; the pre-send checklist will surface every queued step as a delivery issue until a mailbox is connected"
+      :real_send
+    else
+      Rails.logger.warn "[CampaignSweepJob] sending disabled in #{Rails.env}; set TEST_TO_EMAIL to redirect mail, or run in production"
+      :skip
+    end
+  end
 
   def recipient_for(host)
     self.class.test_to_email_override || host.customer_email
   end
 
+  # Minimal candidate filter: pending steps whose planned_delivery_at has
+  # passed. Everything else (campaign run status, proposal stage, suppression,
+  # idempotency, …) lives in PreSendChecklist so the UI and the sweep agree
+  # on what would block.
   def due_step_instance_ids(now)
     CampaignStepInstance
-      .joins(campaign_instance: :campaign)
-      .joins("INNER JOIN job_proposals ON job_proposals.id = campaign_instances.host_id AND campaign_instances.host_type = 'JobProposal'")
       .where(email_delivery_status: :pending)
-      .where("campaign_step_instances.planned_delivery_at <= ?", now)
-      .where(campaign_instances: { status: CampaignInstance.statuses[:active] })
-      .where(campaigns: { status: Campaign.statuses[:approved] })
-      .where(job_proposals: { status: JobProposal.statuses[:approved] })
-      .pluck("campaign_step_instances.id")
+      .where("planned_delivery_at <= ?", now)
+      .pluck(:id)
   end
 
-  def process(step_instance_id, mailbox)
-    return unless claim(step_instance_id)
-
+  def process(step_instance_id, mailbox, mode)
     step_instance = CampaignStepInstance.find(step_instance_id)
+
+    if mode == :dev_letter_opener || mode == :fake_send
+      return unless claim(step_instance_id)
+      step_instance.reload
+      simulated_send(step_instance, mode)
+      return
+    end
+
+    blocker = PreSendChecklist.run(step_instance).find(&:fail?)
+    if blocker
+      handle_blocked(step_instance, blocker)
+      return
+    end
+
+    return unless claim(step_instance_id)
+    step_instance.reload
     deliver(step_instance, mailbox)
+  end
+
+  def handle_blocked(step_instance, blocker)
+    case blocker.status
+    when PreSendChecklist::BLOCK_SILENT
+      Rails.logger.info(
+        "[CampaignSweepJob] step #{step_instance.id} blocked silently by checklist " \
+        "(#{blocker.key}): #{blocker.detail}"
+      )
+    when PreSendChecklist::BLOCK_DELIVERY_ISSUE
+      Rails.logger.warn(
+        "[CampaignSweepJob] step #{step_instance.id} blocked with delivery issue " \
+        "(#{blocker.key}): #{blocker.detail}"
+      )
+      claim_to_failed(step_instance)
+    end
   end
 
   # Atomically transitions pending -> sending. Returns true if this worker
@@ -118,22 +149,27 @@ class CampaignSweepJob < ApplicationJob
     rows.positive?
   end
 
+  # Atomically transitions pending -> failed and stops the campaign run.
+  # The conditional update_all guarantees we only act once per step even if
+  # two sweeps overlap.
+  def claim_to_failed(step_instance)
+    rows = CampaignStepInstance
+      .where(id: step_instance.id, email_delivery_status: :pending)
+      .update_all(
+        email_delivery_status: CampaignStepInstance.email_delivery_statuses[:failed],
+        updated_at: Time.current
+      )
+    return unless rows.positive?
+
+    instance = step_instance.campaign_instance
+    instance.reload
+    instance.update!(status: :stopped_on_delivery_issue, ended_at: Time.current) if instance.status_active?
+  end
+
   def deliver(step_instance, mailbox)
     instance = step_instance.campaign_instance
     host = instance.host
-
-    unless host.is_a?(JobProposal)
-      Rails.logger.warn "[CampaignSweepJob] unsupported host #{host.class.name} for step instance #{step_instance.id}"
-      mark_failed(step_instance, instance)
-      return
-    end
-
     recipient = recipient_for(host)
-    if recipient.blank?
-      Rails.logger.warn "[CampaignSweepJob] no recipient resolvable for JobProposal #{host.id} (customer_email blank, no TEST_TO_EMAIL override) on step instance #{step_instance.id}"
-      mark_failed(step_instance, instance)
-      return
-    end
 
     # Content is locked in at approve time (see JobProposalsController#approve).
     # The sweep just ships the persisted final_subject / final_body — no late
@@ -141,11 +177,6 @@ class CampaignSweepJob < ApplicationJob
     # a queued email.
     subject = step_instance.final_subject
     body    = step_instance.final_body
-    if subject.blank?
-      Rails.logger.warn "[CampaignSweepJob] step instance #{step_instance.id} has no final_subject — was it approved?"
-      mark_failed(step_instance, instance)
-      return
-    end
 
     # Display name on the From header is the proposal owner's full
     # name (Mike Frizzell), so the recipient sees
@@ -161,30 +192,9 @@ class CampaignSweepJob < ApplicationJob
     # to admins deleting and re-adding step 1.
     attachments = first_step?(step_instance) ? pdf_attachments_for(host) : []
 
-    sender = mailbox ? GmailSender.new(mailbox) : nil
-    delivery_failed = false
-    send_response = nil
-
-    if self.class.development_environment?
-      # Dev: hand the prepared message off to Action Mailer, which routes
-      # through letter_opener_web. No Gmail call, no thread metadata to
-      # capture — reply polling and delivery-issue detection are
-      # production-only concerns.
-      CampaignStepMailer.with(
-        to:          recipient,
-        subject:     subject,
-        body:        body.to_s,
-        from_name:   from_name,
-        attachments: attachments
-      ).step.deliver_now
-    elsif sender
-      send_response = sender.send_email(to: recipient, subject: subject, body: body.to_s, from_name: from_name, attachments: attachments)
-      delivery_failed = send_response.nil?
-    else
-      Rails.logger.info "[CampaignSweepJob][FAKE-SEND] step #{step_instance.id} -> #{recipient} (from #{from_name.inspect}, #{attachments.size} attachment(s)): #{subject.inspect}"
-    end
-
-    if delivery_failed
+    sender = GmailSender.new(mailbox)
+    send_response = sender.send_email(to: recipient, subject: subject, body: body.to_s, from_name: from_name, attachments: attachments)
+    if send_response.nil?
       mark_failed(step_instance, instance)
       return
     end
@@ -197,6 +207,50 @@ class CampaignSweepJob < ApplicationJob
     mark_failed(step_instance, instance)
   end
 
+  # Dev/letter_opener and FAKE-SEND paths. No real Gmail call, no thread
+  # metadata to capture — reply polling and delivery-issue detection are
+  # production-only concerns. The checklist is intentionally bypassed for
+  # both modes (they don't reach a real customer).
+  def simulated_send(step_instance, mode)
+    instance = step_instance.campaign_instance
+    host = instance.host
+    recipient = recipient_for(host)
+    if recipient.blank?
+      Rails.logger.warn "[CampaignSweepJob] no recipient resolvable for step instance #{step_instance.id} in #{mode} mode"
+      mark_failed(step_instance, instance)
+      return
+    end
+
+    subject = step_instance.final_subject
+    body    = step_instance.final_body
+    if subject.blank?
+      Rails.logger.warn "[CampaignSweepJob] step instance #{step_instance.id} has no final_subject in #{mode} mode — was it approved?"
+      mark_failed(step_instance, instance)
+      return
+    end
+
+    from_name = host.owner&.full_name
+    attachments = first_step?(step_instance) ? pdf_attachments_for(host) : []
+
+    if mode == :dev_letter_opener
+      CampaignStepMailer.with(
+        to:          recipient,
+        subject:     subject,
+        body:        body.to_s,
+        from_name:   from_name,
+        attachments: attachments
+      ).step.deliver_now
+    else
+      Rails.logger.info "[CampaignSweepJob][FAKE-SEND] step #{step_instance.id} -> #{recipient} (from #{from_name.inspect}, #{attachments.size} attachment(s)): #{subject.inspect}"
+    end
+
+    step_instance.update!(email_delivery_status: :sent)
+    complete_instance_if_done(instance)
+  rescue StandardError => e
+    Rails.logger.error "[CampaignSweepJob] unexpected error in #{mode} send for step instance #{step_instance.id}: #{e.class}: #{e.message}"
+    mark_failed(step_instance, instance)
+  end
+
   # Stores the Gmail send response and (best-effort) the thread snapshot
   # captured immediately after send. The snapshot is the baseline the
   # GmailReplyPollJob compares against to detect customer replies. A
@@ -204,7 +258,7 @@ class CampaignSweepJob < ApplicationJob
   # log and leave gmail_thread_snapshot nil so the poller can fill it in
   # on its first pass.
   def persist_send_metadata(step_instance, sender, send_response)
-    return if send_response.nil? # fake-send path
+    return if send_response.nil?
 
     thread_id = send_response["threadId"]
     thread_snapshot = nil

--- a/app/models/email_suppression.rb
+++ b/app/models/email_suppression.rb
@@ -1,0 +1,29 @@
+# Per-location list of email addresses we will not send to. Per PRD-09 §11,
+# entries are added on hard bounce, explicit unsubscribe, or spam complaint
+# and only cleared by a SMAI admin. Auto-population from inbound delivery
+# events is future work — for now the table is empty unless an admin adds
+# rows manually, and PreSendChecklist check #7 simply passes when nothing
+# matches.
+class EmailSuppression < ApplicationRecord
+  belongs_to :location
+
+  REASONS = %w[hard_bounce unsubscribe spam_complaint manual].freeze
+
+  validates :email, presence: true,
+                    format: { with: URI::MailTo::EMAIL_REGEXP },
+                    uniqueness: { scope: :location_id, case_sensitive: false }
+  validates :reason, inclusion: { in: REASONS }
+
+  before_validation :normalize_email
+
+  def self.suppressed?(location:, email:)
+    return false if location.blank? || email.blank?
+    where(location_id: location.id).where("LOWER(email) = ?", email.to_s.strip.downcase).exists?
+  end
+
+  private
+
+  def normalize_email
+    self.email = email.to_s.strip.downcase if email.present?
+  end
+end

--- a/app/models/job_proposal.rb
+++ b/app/models/job_proposal.rb
@@ -99,6 +99,22 @@ class JobProposal < ApplicationRecord
     self.class.cta_for(pipeline_stage: pipeline_stage, status_overlay: status_overlay)
   end
 
+  # The campaign step instance that would ship next if the sweep ran right
+  # now: the lowest-sequence pending step on the most-recent campaign run.
+  # Returns nil when no pending step exists (no run yet, or every step has
+  # already shipped). Used by the proposal show page to evaluate the
+  # PreSendChecklist for what the operator should fix before the next send.
+  def next_pending_step_instance
+    instance = campaign_instances.order(created_at: :desc).first
+    return nil unless instance
+
+    instance.step_instances
+      .where(email_delivery_status: :pending)
+      .joins(:campaign_step)
+      .order("campaign_steps.sequence_number ASC")
+      .first
+  end
+
   # Most recent gmail thread id from any of this proposal's campaign step
   # instances. nil when no email has been sent yet. Used to deep-link the
   # operator into the Gmail conversation when the customer replies.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,6 +5,7 @@ class Location < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :invitations, dependent: :nullify
   has_many :job_proposals, dependent: :nullify
+  has_many :email_suppressions, dependent: :destroy
 
   validates :display_name, presence: true
   validates :address_line_1, presence: true

--- a/app/services/pre_send_checklist.rb
+++ b/app/services/pre_send_checklist.rb
@@ -1,0 +1,233 @@
+# Single source of truth for the conditions that must hold before a customer
+# email leaves the system. Both the runtime sender (CampaignSweepJob) and the
+# operator UI (JobProposal show page) call into this same class so what the
+# operator sees on the page is exactly what the sweep will evaluate when the
+# step's planned_delivery_at arrives.
+#
+# Authority: PRD-09 v1.3 §9.2 defines the canonical seven checks. We add an
+# eighth defensive guard for rendered step content because in our codebase
+# content is locked at approve time (not at send time) and a step instance
+# without final_subject indicates an upstream issue that would otherwise
+# silently fail.
+#
+# Failure classes (per PRD-09 §9.2):
+# - :block_silent          — drop the task, log, do nothing else. The state
+#                            will resolve when the underlying condition does
+#                            (operator resumes campaign, status overlay
+#                            clears, etc.).
+# - :block_delivery_issue  — block the send AND surface a delivery_issue
+#                            overlay on the proposal so the operator can
+#                            fix the input (mailbox, recipient, suppression).
+class PreSendChecklist
+  Check = Struct.new(:key, :label, :status, :detail, :remedy, keyword_init: true) do
+    def pass? = status == :pass
+    def fail? = !pass?
+    def block_delivery_issue? = status == :block_delivery_issue
+    def block_silent? = status == :block_silent
+  end
+
+  PASS = :pass
+  BLOCK_SILENT = :block_silent
+  BLOCK_DELIVERY_ISSUE = :block_delivery_issue
+
+  def self.run(step_instance)
+    new(step_instance).run
+  end
+
+  def initialize(step_instance)
+    @step_instance = step_instance
+    @campaign_instance = step_instance.campaign_instance
+    @job_proposal = @campaign_instance&.host
+  end
+
+  def run
+    [
+      check_mailbox_connected,
+      check_pipeline_stage,
+      check_status_overlay,
+      check_campaign_active,
+      check_idempotency,
+      check_contact_email,
+      check_suppression,
+      check_step_content
+    ]
+  end
+
+  def pass?
+    run.all?(&:pass?)
+  end
+
+  # First failing check, or nil when everything passes. This is what callers
+  # branch on — the failure class lives on the Check itself.
+  def first_blocker
+    run.find(&:fail?)
+  end
+
+  private
+
+  attr_reader :step_instance, :campaign_instance, :job_proposal
+
+  def check_mailbox_connected
+    mailbox = ApplicationMailbox.current
+    if mailbox.nil?
+      fail_check(:mailbox_connected, "Mailbox connected", BLOCK_DELIVERY_ISSUE,
+                 "No Gmail mailbox is connected for this tenant.",
+                 "Connect a mailbox in Settings → Integrations.")
+    elsif mailbox.expired? && mailbox.refresh_token.blank?
+      fail_check(:mailbox_connected, "Mailbox connected", BLOCK_DELIVERY_ISSUE,
+                 "The connected Gmail mailbox's authorization has expired and there is no refresh token.",
+                 "Reconnect the mailbox in Settings → Integrations.")
+    else
+      pass_check(:mailbox_connected, "Mailbox connected")
+    end
+  end
+
+  def check_pipeline_stage
+    return missing_proposal(:pipeline_stage, "Job is in campaign") if job_proposal.nil?
+
+    if job_proposal.status_approved? && job_proposal.pipeline_stage_in_campaign?
+      pass_check(:pipeline_stage, "Job is in campaign")
+    else
+      fail_check(:pipeline_stage, "Job is in campaign", BLOCK_SILENT,
+                 "This job's pipeline stage is #{describe(job_proposal.pipeline_stage)} (status: #{describe(job_proposal.status)}).",
+                 "A campaign only sends while the job sits in the in-campaign stage.")
+    end
+  end
+
+  def check_status_overlay
+    return missing_proposal(:status_overlay, "No blocking status overlay") if job_proposal.nil?
+
+    if job_proposal.status_overlay.blank?
+      pass_check(:status_overlay, "No blocking status overlay")
+    else
+      fail_check(:status_overlay, "No blocking status overlay", BLOCK_SILENT,
+                 "This job has a #{job_proposal.status_overlay.humanize.downcase} overlay.",
+                 overlay_remedy(job_proposal.status_overlay))
+    end
+  end
+
+  def check_campaign_active
+    return missing_instance(:campaign_active, "Campaign run is active") if campaign_instance.nil?
+
+    unless campaign_instance.status_active?
+      return fail_check(:campaign_active, "Campaign run is active", BLOCK_SILENT,
+                        "The campaign run is currently #{campaign_instance.status.humanize.downcase}.",
+                        "Resume or restart the campaign before any further steps can ship.")
+    end
+
+    # The underlying campaign template can be paused by a SMAI admin to halt
+    # every active run across all tenants. Operators can't unpause a template
+    # — surfacing this as a distinct failure helps support diagnose quickly.
+    template = campaign_instance.campaign
+    unless template&.status_approved?
+      return fail_check(:campaign_active, "Campaign run is active", BLOCK_SILENT,
+                        "The campaign behind this run is currently #{template&.status.to_s.humanize.downcase.presence || 'unavailable'}.",
+                        "A SMAI admin must re-approve the campaign template before any of its runs can ship steps.")
+    end
+
+    pass_check(:campaign_active, "Campaign run is active")
+  end
+
+  # Idempotency in our model: a step instance moves pending → sending → sent.
+  # The send is safe to attempt while it is still pending or sending. Once it
+  # has reached sent / failed / bounced, the step is terminal and a duplicate
+  # send must not happen. This matches PRD-09 §9.2 check 5 ("no existing
+  # messages row for this campaign_run + step_order with status = sent").
+  def check_idempotency
+    case step_instance.email_delivery_status
+    when "pending", "sending"
+      pass_check(:idempotency, "Not already sent")
+    when "sent"
+      fail_check(:idempotency, "Not already sent", BLOCK_SILENT,
+                 "This campaign step has already been sent.",
+                 "No action needed — this is a duplicate-send guard.")
+    else
+      fail_check(:idempotency, "Not already sent", BLOCK_SILENT,
+                 "This campaign step is in a terminal state (#{step_instance.email_delivery_status}).",
+                 "The next campaign step (or a recovery flow) handles the next send.")
+    end
+  end
+
+  def check_contact_email
+    return missing_proposal(:contact_email, "Recipient email present and valid") if job_proposal.nil?
+
+    email = job_proposal.customer_email.to_s.strip
+    if email.blank?
+      fail_check(:contact_email, "Recipient email present and valid", BLOCK_DELIVERY_ISSUE,
+                 "The customer email field is blank.",
+                 "Add the customer's email on the proposal Edit page.")
+    elsif !valid_email_format?(email)
+      fail_check(:contact_email, "Recipient email present and valid", BLOCK_DELIVERY_ISSUE,
+                 "The customer email \"#{email}\" is not a valid email address.",
+                 "Correct the customer email on the proposal Edit page.")
+    else
+      pass_check(:contact_email, "Recipient email present and valid")
+    end
+  end
+
+  def check_suppression
+    return missing_proposal(:suppression, "Recipient is not on the suppression list") if job_proposal.nil?
+
+    email = job_proposal.customer_email.to_s.strip
+    location = job_proposal.location
+    if email.blank? || location.nil?
+      pass_check(:suppression, "Recipient is not on the suppression list")
+    elsif EmailSuppression.suppressed?(location: location, email: email)
+      fail_check(:suppression, "Recipient is not on the suppression list", BLOCK_DELIVERY_ISSUE,
+                 "The address #{email} is on the suppression list for this location.",
+                 "A SMAI admin must clear the suppression entry before the campaign can resume.")
+    else
+      pass_check(:suppression, "Recipient is not on the suppression list")
+    end
+  end
+
+  def check_step_content
+    if step_instance.final_subject.present?
+      pass_check(:step_content, "Step content rendered")
+    else
+      # Treated as a delivery_issue so the step is marked failed and the run
+      # is stopped — a step with no rendered subject is a terminal upstream
+      # defect and we don't want it to retry forever.
+      fail_check(:step_content, "Step content rendered", BLOCK_DELIVERY_ISSUE,
+                 "The step has no rendered subject. The campaign was likely approved before this step's content was generated.",
+                 "Re-approve the campaign, or contact support if the issue persists.")
+    end
+  end
+
+  def overlay_remedy(overlay)
+    case overlay
+    when "paused"            then "Resume the campaign from the proposal page."
+    when "delivery_issue"    then "Use Fix Issue on the proposal to correct the recipient and resume."
+    when "customer_waiting"  then "The customer has replied — handle the reply, then resume if appropriate."
+    else                          "Clear the overlay before this step can ship."
+    end
+  end
+
+  def missing_proposal(key, label)
+    fail_check(key, label, BLOCK_SILENT,
+               "The campaign step is not attached to a job proposal.",
+               "This is a system error; contact support.")
+  end
+
+  def missing_instance(key, label)
+    fail_check(key, label, BLOCK_SILENT,
+               "The campaign step is not attached to a campaign run.",
+               "This is a system error; contact support.")
+  end
+
+  def pass_check(key, label)
+    Check.new(key: key, label: label, status: PASS)
+  end
+
+  def fail_check(key, label, status, detail, remedy)
+    Check.new(key: key, label: label, status: status, detail: detail, remedy: remedy)
+  end
+
+  def valid_email_format?(email)
+    email.match?(URI::MailTo::EMAIL_REGEXP)
+  end
+
+  def describe(value)
+    value.presence&.to_s&.humanize&.downcase || "blank"
+  end
+end

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -140,6 +140,56 @@
   </div>
 <% end %>
 
+<% next_pending = @job_proposal.next_pending_step_instance %>
+<% if next_pending %>
+  <% checks = PreSendChecklist.run(next_pending) %>
+  <% has_action_needed = checks.any? { |c| c.status == :block_delivery_issue } %>
+  <% has_waiting = checks.any? { |c| c.status == :block_silent } %>
+  <div class="card shadow-sm mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h2 class="h5 mb-0">Pre-send checklist</h2>
+      <% if has_action_needed %>
+        <span class="badge text-bg-danger">Action needed</span>
+      <% elsif has_waiting %>
+        <span class="badge text-bg-warning">Waiting on a condition</span>
+      <% else %>
+        <span class="badge text-bg-success">Ready to send</span>
+      <% end %>
+    </div>
+    <div class="card-body p-0">
+      <p class="px-3 pt-3 mb-2 small text-muted">
+        Every customer email is checked against this list right before it ships.
+        Anything red here must be cleared before the next campaign step can go out.
+      </p>
+      <ul class="list-group list-group-flush">
+        <% checks.each do |check| %>
+          <li class="list-group-item">
+            <div class="d-flex align-items-center gap-2">
+              <% case check.status
+                 when :pass %>
+                <span class="badge text-bg-success">Pass</span>
+              <% when :block_delivery_issue %>
+                <span class="badge text-bg-danger">Action needed</span>
+              <% else %>
+                <span class="badge text-bg-warning">Waiting</span>
+              <% end %>
+              <span class="fw-semibold"><%= check.label %></span>
+            </div>
+            <% if check.fail? %>
+              <div class="small text-muted ms-1 mt-1">
+                <%= check.detail %>
+                <% if check.remedy.present? %>
+                  <br><strong>How to fix:</strong> <%= check.remedy %>
+                <% end %>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <% campaign_instance = @job_proposal.campaign_instances.order(created_at: :desc).first %>
 <div class="card shadow-sm mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">

--- a/db/migrate/20260510120000_create_email_suppressions.rb
+++ b/db/migrate/20260510120000_create_email_suppressions.rb
@@ -1,0 +1,13 @@
+class CreateEmailSuppressions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :email_suppressions do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :email, null: false
+      t.string :reason, null: false
+      t.text :notes
+      t.timestamps
+    end
+
+    add_index :email_suppressions, [:location_id, :email], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_10_024000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -167,6 +167,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_024000) do
     t.bigint "user_id", null: false
     t.index ["user_id", "provider", "email"], name: "index_email_delegations_on_user_id_and_provider_and_email", unique: true
     t.index ["user_id"], name: "index_email_delegations_on_user_id"
+  end
+
+  create_table "email_suppressions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.bigint "location_id", null: false
+    t.text "notes"
+    t.string "reason", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id", "email"], name: "index_email_suppressions_on_location_id_and_email", unique: true
+    t.index ["location_id"], name: "index_email_suppressions_on_location_id"
   end
 
   create_table "integration_checks", force: :cascade do |t|
@@ -457,6 +468,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_10_024000) do
   add_foreign_key "campaigns", "users", column: "paused_by_user_id"
   add_foreign_key "chats", "models"
   add_foreign_key "email_delegations", "users"
+  add_foreign_key "email_suppressions", "locations"
   add_foreign_key "invitations", "locations"
   add_foreign_key "invitations", "tenants"
   add_foreign_key "invitations", "users", column: "invited_by_user_id"

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -242,6 +242,54 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     refute_match si_no_thread.id.to_s + "[^\"]*Open", response.body
   end
 
+  # --- pre-send checklist card ---
+
+  test "show renders the pre-send checklist for a proposal with a pending campaign step" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(status: :approved, pipeline_stage: :in_campaign, customer_email: "alice@example.com")
+    instance = CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active)
+    CampaignStepInstance.create!(
+      campaign_instance: instance, campaign_step: campaign_steps(:approved_step_one),
+      planned_delivery_at: 1.hour.from_now, email_delivery_status: :pending,
+      final_subject: "ready", final_body: "hi"
+    )
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_select "h2", text: "Pre-send checklist"
+    assert_match "Mailbox connected", response.body
+    assert_match "Recipient email present and valid", response.body
+    assert_match "Recipient is not on the suppression list", response.body
+  end
+
+  test "show flags 'Action needed' when a delivery-issue check fails" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(status: :approved, pipeline_stage: :in_campaign, customer_email: nil)
+    instance = CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :active)
+    CampaignStepInstance.create!(
+      campaign_instance: instance, campaign_step: campaign_steps(:approved_step_one),
+      planned_delivery_at: 1.hour.from_now, email_delivery_status: :pending,
+      final_subject: "x", final_body: "y"
+    )
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_match "Action needed", response.body
+    assert_match "customer email field is blank", response.body
+  end
+
+  test "show hides the pre-send checklist when there is no pending campaign step" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    # No CampaignInstance at all.
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_no_match "Pre-send checklist", response.body
+  end
+
   # --- sort ---
 
   test "default sort is created_at desc" do

--- a/test/jobs/campaign_sweep_job_test.rb
+++ b/test/jobs/campaign_sweep_job_test.rb
@@ -16,8 +16,13 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     # status:approved is the operator-explicit "go" gate the sweep checks
     # before sending. Existing tests pre-date this gate; default to approved
     # and let any gate-specific tests below override.
+    # status:approved gates operator approval. pipeline_stage:in_campaign
+    # is the canonical PRD-09 §9.2 check-2 condition for a job that has
+    # been launched into a campaign — fixtures don't set it explicitly,
+    # so plug it in here so the pre-send checklist passes.
     @proposal.update!(
       status: :approved,
+      pipeline_stage: :in_campaign,
       customer_email: "alice@example.com",
       customer_house_number: "100",
       customer_street: "Oak Ridge"
@@ -287,13 +292,17 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     assert_nil step_instance.gmail_thread_snapshot
   end
 
-  test "skips the sweep entirely outside development when no mailbox is connected" do
+  test "in production with no mailbox, the checklist surfaces a delivery issue on every queued step" do
+    # Per PRD-09 §10.1 a disconnected mailbox is a delivery_issue, not a
+    # silent skip. The checklist's mailbox check fires first; the step is
+    # marked failed and the campaign run is stopped.
     @mailbox.destroy!
     step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
 
     with_production_environment(true) { CampaignSweepJob.new.perform }
 
-    assert_equal "pending", step_instance.reload.email_delivery_status
+    assert_equal "failed", step_instance.reload.email_delivery_status
+    assert_equal "stopped_on_delivery_issue", @instance.reload.status
     assert_empty GmailSender.deliveries
   end
 
@@ -341,6 +350,43 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     # No Gmail metadata captured — the dev path skips persist_send_metadata.
     assert_nil step_instance.gmail_send_response
     assert_nil step_instance.gmail_thread_id
+  end
+
+  test "skips a step silently when the proposal has a status_overlay set" do
+    @proposal.update!(status_overlay: "paused")
+    step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
+
+    CampaignSweepJob.new.perform
+
+    assert_equal "pending", step_instance.reload.email_delivery_status, "block_silent should leave the step pending"
+    assert_equal "active", @instance.reload.status, "block_silent should not stop the campaign run"
+    assert_empty GmailSender.deliveries
+  end
+
+  test "marks step failed and stops instance when the recipient is on the suppression list" do
+    EmailSuppression.create!(
+      location: @proposal.location,
+      email: @proposal.customer_email,
+      reason: "manual"
+    )
+    step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
+
+    CampaignSweepJob.new.perform
+
+    assert_equal "failed", step_instance.reload.email_delivery_status
+    assert_equal "stopped_on_delivery_issue", @instance.reload.status
+    assert_empty GmailSender.deliveries
+  end
+
+  test "marks step failed and stops instance when the customer email is malformed" do
+    @proposal.update!(customer_email: "not-an-email")
+    step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
+
+    CampaignSweepJob.new.perform
+
+    assert_equal "failed", step_instance.reload.email_delivery_status
+    assert_equal "stopped_on_delivery_issue", @instance.reload.status
+    assert_empty GmailSender.deliveries
   end
 
   test "claim is idempotent across overlapping sweeps" do

--- a/test/models/email_suppression_test.rb
+++ b/test/models/email_suppression_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class EmailSuppressionTest < ActiveSupport::TestCase
+  setup do
+    @location = locations(:ne_dallas)
+  end
+
+  test "is valid with an email, location, and recognised reason" do
+    suppression = EmailSuppression.new(location: @location, email: "spam@example.com", reason: "hard_bounce")
+    assert suppression.valid?
+  end
+
+  test "rejects an unknown reason" do
+    suppression = EmailSuppression.new(location: @location, email: "spam@example.com", reason: "nope")
+    refute suppression.valid?
+    assert_includes suppression.errors[:reason].to_s, "not included"
+  end
+
+  test "rejects a malformed email" do
+    suppression = EmailSuppression.new(location: @location, email: "not-an-email", reason: "manual")
+    refute suppression.valid?
+  end
+
+  test "is unique per (location, email)" do
+    EmailSuppression.create!(location: @location, email: "dupe@example.com", reason: "manual")
+    dup = EmailSuppression.new(location: @location, email: "dupe@example.com", reason: "manual")
+    refute dup.valid?
+  end
+
+  test "uniqueness is case-insensitive" do
+    EmailSuppression.create!(location: @location, email: "case@example.com", reason: "manual")
+    dup = EmailSuppression.new(location: @location, email: "CASE@example.com", reason: "manual")
+    refute dup.valid?
+  end
+
+  test "the same email can be suppressed independently in two locations" do
+    other = Location.create!(
+      tenant: @location.tenant,
+      display_name: "Other",
+      address_line_1: "1 Other Way",
+      city: "Dallas",
+      state: "TX",
+      postal_code: "75001",
+      phone_number: "(555) 555-0001"
+    )
+    EmailSuppression.create!(location: @location, email: "shared@example.com", reason: "manual")
+    second = EmailSuppression.new(location: other, email: "shared@example.com", reason: "manual")
+    assert second.valid?
+  end
+
+  test ".suppressed? returns true for a matching entry, ignoring case and whitespace" do
+    EmailSuppression.create!(location: @location, email: "Match@Example.com", reason: "manual")
+    assert EmailSuppression.suppressed?(location: @location, email: "  match@example.com ")
+  end
+
+  test ".suppressed? returns false when nothing matches" do
+    refute EmailSuppression.suppressed?(location: @location, email: "ghost@example.com")
+  end
+
+  test ".suppressed? short-circuits on blank inputs" do
+    refute EmailSuppression.suppressed?(location: @location, email: nil)
+    refute EmailSuppression.suppressed?(location: nil, email: "x@example.com")
+  end
+end

--- a/test/services/pre_send_checklist_test.rb
+++ b/test/services/pre_send_checklist_test.rb
@@ -1,0 +1,227 @@
+require "test_helper"
+
+class PreSendChecklistTest < ActiveSupport::TestCase
+  setup do
+    @mailbox = ApplicationMailbox.create!(
+      provider: "google",
+      email: "ops@example.com",
+      access_token: "atk",
+      refresh_token: "rtk",
+      expires_at: 1.hour.from_now
+    )
+    @campaign = campaigns(:approved_campaign)
+    @step = campaign_steps(:approved_step_one)
+    @proposal = job_proposals(:in_users_org)
+    @proposal.update!(
+      status: :approved,
+      pipeline_stage: :in_campaign,
+      status_overlay: nil,
+      customer_email: "alice@example.com",
+      customer_house_number: "100",
+      customer_street: "Oak Ridge"
+    )
+    @instance = CampaignInstance.create!(campaign: @campaign, host: @proposal, status: :active)
+    @step_instance = CampaignStepInstance.create!(
+      campaign_instance: @instance,
+      campaign_step: @step,
+      planned_delivery_at: 1.minute.ago,
+      email_delivery_status: :pending,
+      final_subject: "ready to ship",
+      final_body: "hi there"
+    )
+  end
+
+  test "passes every check on a fully ready step" do
+    checks = PreSendChecklist.run(@step_instance)
+
+    assert_equal 8, checks.size, "expected one Check per canonical condition plus the rendered-content guard"
+    assert checks.all?(&:pass?), "expected all checks to pass; failing: #{checks.reject(&:pass?).map(&:key).inspect}"
+  end
+
+  test "labels are operator-friendly" do
+    checks = PreSendChecklist.run(@step_instance)
+
+    assert_match(/mailbox/i, checks.find { |c| c.key == :mailbox_connected }.label)
+    assert_match(/recipient/i, checks.find { |c| c.key == :contact_email }.label)
+    assert_match(/suppression/i, checks.find { |c| c.key == :suppression }.label)
+  end
+
+  test "fails the mailbox check with a delivery_issue when no mailbox is connected" do
+    @mailbox.destroy!
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :mailbox_connected, blocker.key
+    assert blocker.block_delivery_issue?
+    assert_match(/no Gmail mailbox/i, blocker.detail)
+  end
+
+  test "fails the mailbox check with delivery_issue when the token is expired and there is no refresh token" do
+    @mailbox.update!(refresh_token: nil, expires_at: 1.hour.ago)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :mailbox_connected, blocker.key
+    assert blocker.block_delivery_issue?
+  end
+
+  test "passes the mailbox check when an expired token still has a refresh token" do
+    @mailbox.update!(refresh_token: "rtk", expires_at: 1.hour.ago)
+
+    checks = PreSendChecklist.run(@step_instance)
+
+    assert checks.find { |c| c.key == :mailbox_connected }.pass?
+  end
+
+  test "fails pipeline_stage with block_silent when the proposal status is not approved" do
+    @proposal.update!(status: :approving)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :pipeline_stage, blocker.key
+    assert blocker.block_silent?
+  end
+
+  test "fails pipeline_stage with block_silent when the proposal is won" do
+    @proposal.update!(pipeline_stage: :won)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :pipeline_stage, blocker.key
+    assert blocker.block_silent?
+  end
+
+  test "fails status_overlay with block_silent when an overlay is set" do
+    @proposal.update!(status_overlay: "paused")
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :status_overlay, blocker.key
+    assert blocker.block_silent?
+    assert_match(/paused/i, blocker.detail)
+  end
+
+  test "fails campaign_active with block_silent when the campaign run is paused" do
+    @instance.update!(status: :paused)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :campaign_active, blocker.key
+    assert blocker.block_silent?
+  end
+
+  test "fails campaign_active with block_silent when the campaign template is paused" do
+    @campaign.update!(status: :paused, paused_by_user: users(:one), paused_at: Time.current)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :campaign_active, blocker.key
+    assert blocker.block_silent?
+    assert_match(/campaign behind/i, blocker.detail)
+  end
+
+  test "fails idempotency with block_silent when the step has already been sent" do
+    @step_instance.update!(email_delivery_status: :sent)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :idempotency, blocker.key
+    assert blocker.block_silent?
+  end
+
+  test "passes idempotency while the step is in flight (sending)" do
+    @step_instance.update!(email_delivery_status: :sending)
+
+    checks = PreSendChecklist.run(@step_instance)
+
+    assert checks.find { |c| c.key == :idempotency }.pass?
+  end
+
+  test "fails contact_email with delivery_issue when the customer email is blank" do
+    @proposal.update!(customer_email: nil)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :contact_email, blocker.key
+    assert blocker.block_delivery_issue?
+  end
+
+  test "fails contact_email with delivery_issue when the customer email is malformed" do
+    @proposal.update!(customer_email: "not-an-email")
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :contact_email, blocker.key
+    assert blocker.block_delivery_issue?
+  end
+
+  test "fails suppression with delivery_issue when the recipient is on the location suppression list" do
+    EmailSuppression.create!(
+      location: @proposal.location,
+      email: "alice@example.com",
+      reason: "manual"
+    )
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :suppression, blocker.key
+    assert blocker.block_delivery_issue?
+  end
+
+  test "suppression check is case-insensitive on the email address" do
+    EmailSuppression.create!(
+      location: @proposal.location,
+      email: "ALICE@example.com",
+      reason: "manual"
+    )
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :suppression, blocker.key
+  end
+
+  test "suppression check is scoped per location" do
+    other_location = Location.create!(
+      tenant: @proposal.tenant,
+      display_name: "Other branch",
+      address_line_1: "1 Elsewhere Pl",
+      city: "Dallas",
+      state: "TX",
+      postal_code: "75001",
+      phone_number: "(555) 555-5555"
+    )
+    EmailSuppression.create!(
+      location: other_location,
+      email: "alice@example.com",
+      reason: "manual"
+    )
+
+    checks = PreSendChecklist.run(@step_instance)
+
+    assert checks.find { |c| c.key == :suppression }.pass?,
+      "a suppression entry on a different location must not block this proposal"
+  end
+
+  test "fails step_content with delivery_issue when the rendered subject is blank" do
+    @step_instance.update!(final_subject: nil)
+
+    blocker = PreSendChecklist.new(@step_instance).first_blocker
+
+    assert_equal :step_content, blocker.key
+    assert blocker.block_delivery_issue?
+  end
+
+  test "first_blocker returns nil when nothing is wrong" do
+    assert_nil PreSendChecklist.new(@step_instance).first_blocker
+  end
+
+  test "pass? is true when every check passes" do
+    assert PreSendChecklist.new(@step_instance).pass?
+  end
+
+  test "pass? is false when any check fails" do
+    @proposal.update!(customer_email: nil)
+
+    refute PreSendChecklist.new(@step_instance).pass?
+  end
+end


### PR DESCRIPTION
Per PRD-09 §9.2, customer email sends must pass a fixed checklist right before they leave the system. Today those conditions were scattered across CampaignSweepJob's SQL filter, atomic claim, inline recipient/subject guards, and were not surfaced to the operator at all. Move them into a single PreSendChecklist service that both the sweep job and the proposal show page run through.

- Add PreSendChecklist (app/services/pre_send_checklist.rb) with the seven canonical checks plus a defensive guard for rendered step content. Each check returns an operator-facing label, detail, and remedy and tags itself with a failure class (block_silent leaves the step pending; block_delivery_issue marks the step failed and stops the run with stopped_on_delivery_issue).
- Rewrite CampaignSweepJob#process to evaluate the checklist on every due step before claiming. Dev/letter_opener and FAKE-SEND modes bypass it (they don't reach a real customer).
- Add EmailSuppression (location-scoped suppression list) so check 7 has a real backing model. Empty by default; admin-managed for now.
- Render a Pre-send checklist card on the JobProposal show page so operators see exactly what would block the next send and how to fix it.