### PR TITLE
gmail: send as the originator + fix empty body on attachment sends

### DIFF
--- a/app/jobs/campaign_sweep_job.rb
+++ b/app/jobs/campaign_sweep_job.rb
@@ -2,13 +2,19 @@ require "net/http"
 
 # Runs every 5 minutes (see config/sidekiq_cron.yml) to find campaign step
 # instances whose planned_delivery_at has passed and either ship them via the
-# connected Gmail mailbox or block them — whichever the PreSendChecklist says.
+# proposal originator's connected Gmail or block them — whichever the
+# PreSendChecklist says.
+#
+# Send identity (PRD-09 v1.3 §1, SPEC-07): customer email goes out from the
+# proposal originator's own Gmail account, authenticated via that user's
+# EmailDelegation. The shared ApplicationMailbox is used only for
+# transactional system mail (Devise resets, invitations) — never for
+# customer campaign sends.
 #
 # The checklist (app/services/pre_send_checklist.rb, modeled on PRD-09 v1.3
 # §9.2) is the single source of truth for what must hold before a real
 # customer email leaves the system. Both this job and the operator UI on
-# the proposal page run through the same checklist function so what the
-# operator sees is exactly what the sweep will evaluate next.
+# the proposal page run through the same checklist function.
 #
 # Failure handling, per the checklist's failure class:
 # - :block_silent          — step stays pending, the next sweep re-evaluates.
@@ -21,29 +27,34 @@ require "net/http"
 class CampaignSweepJob < ApplicationJob
   queue_as :default
 
-  # Send-mode resolution for a given run:
+  # Send-mode resolution for a given run. ApplicationMailbox is used here only
+  # as a "real-send environment is configured" sentinel — the actual credential
+  # for a customer send is the originator's per-user EmailDelegation, looked up
+  # in #deliver. The mailbox stays in the picture because it gates Devise/
+  # invitation transactional mail and signals that the host has real Gmail
+  # traffic configured at all.
   #
   #   1. development                                  -> :dev_letter_opener (route through
   #                                                      CampaignStepMailer + letter_opener_web).
-  #                                                      Mailbox state is irrelevant in dev;
-  #                                                      we never want real Gmail traffic.
   #                                                      Checklist bypassed.
-  #   2. mailbox + (production OR TEST_TO_EMAIL)      -> :real_send. Checklist runs.
+  #   2. mailbox + (production OR TEST_TO_EMAIL)      -> :real_send. Checklist runs; the
+  #                                                      originator-mailbox check enforces
+  #                                                      per-proposal Gmail delegation.
   #   3. no mailbox + non-prod                        -> :fake_send. Render the email,
   #                                                      log it, mark the step :sent.
   #                                                      Checklist bypassed — lets tests
   #                                                      exercise the campaign lifecycle
   #                                                      without real Gmail.
   #   4. no mailbox + prod                            -> :real_send. The checklist's
-  #                                                      mailbox check surfaces every
-  #                                                      pending step as a delivery_issue
-  #                                                      so the operator sees the outage.
+  #                                                      originator-mailbox check
+  #                                                      surfaces the outage as a
+  #                                                      delivery issue on each step.
   #   5. mailbox + non-prod + no TEST_TO_EMAIL        -> :skip. Staging guardrail; we
-  #                                                      will not relay through a real
-  #                                                      Gmail mailbox by accident.
+  #                                                      will not relay through real
+  #                                                      Gmail by accident.
   #
-  # Devise mailers (password reset, registration) are unaffected — they go
-  # through Action Mailer, not this job.
+  # Devise mailers (password reset, registration, invitations) are unaffected —
+  # they go through Action Mailer using the shared ApplicationMailbox.
 
   def self.production_environment?
     Rails.env.production?
@@ -58,11 +69,10 @@ class CampaignSweepJob < ApplicationJob
   end
 
   def perform
-    mailbox = ApplicationMailbox.current
-    mode = resolve_mode(mailbox)
+    mode = resolve_mode(ApplicationMailbox.current)
     return if mode == :skip
 
-    due_step_instance_ids(Time.current).each { |id| process(id, mailbox, mode) }
+    due_step_instance_ids(Time.current).each { |id| process(id, mode) }
   end
 
   private
@@ -74,10 +84,10 @@ class CampaignSweepJob < ApplicationJob
     elsif mailbox && (self.class.production_environment? || self.class.test_to_email_override)
       :real_send
     elsif mailbox.nil? && !self.class.production_environment?
-      Rails.logger.info "[CampaignSweepJob] no application mailbox connected; running in FAKE-SEND mode (no real email leaves the host)"
+      Rails.logger.info "[CampaignSweepJob] no application mailbox configured; running in FAKE-SEND mode (no real email leaves the host)"
       :fake_send
     elsif mailbox.nil? && self.class.production_environment?
-      Rails.logger.warn "[CampaignSweepJob] no application mailbox connected; the pre-send checklist will surface every queued step as a delivery issue until a mailbox is connected"
+      Rails.logger.warn "[CampaignSweepJob] no application mailbox configured in production; the pre-send checklist will surface the outage on each queued step"
       :real_send
     else
       Rails.logger.warn "[CampaignSweepJob] sending disabled in #{Rails.env}; set TEST_TO_EMAIL to redirect mail, or run in production"
@@ -100,7 +110,7 @@ class CampaignSweepJob < ApplicationJob
       .pluck(:id)
   end
 
-  def process(step_instance_id, mailbox, mode)
+  def process(step_instance_id, mode)
     step_instance = CampaignStepInstance.find(step_instance_id)
 
     if mode == :dev_letter_opener || mode == :fake_send
@@ -118,7 +128,7 @@ class CampaignSweepJob < ApplicationJob
 
     return unless claim(step_instance_id)
     step_instance.reload
-    deliver(step_instance, mailbox)
+    deliver(step_instance)
   end
 
   def handle_blocked(step_instance, blocker)
@@ -166,10 +176,22 @@ class CampaignSweepJob < ApplicationJob
     instance.update!(status: :stopped_on_delivery_issue, ended_at: Time.current) if instance.status_active?
   end
 
-  def deliver(step_instance, mailbox)
+  def deliver(step_instance)
     instance = step_instance.campaign_instance
     host = instance.host
     recipient = recipient_for(host)
+
+    # Per PRD-09 §1, the originator's own Gmail delegation is the credential.
+    # The checklist's originator_mailbox check would have blocked us already
+    # if this were missing, but a delegation can vanish between the checklist
+    # run and the claim — fall back to delivery-issue handling rather than
+    # crashing.
+    delegation = host.owner&.gmail_delegation
+    if delegation.nil?
+      Rails.logger.warn "[CampaignSweepJob] originator delegation disappeared between checklist and send for step #{step_instance.id}"
+      mark_failed(step_instance, instance)
+      return
+    end
 
     # Content is locked in at approve time (see JobProposalsController#approve).
     # The sweep just ships the persisted final_subject / final_body — no late
@@ -178,12 +200,11 @@ class CampaignSweepJob < ApplicationJob
     subject = step_instance.final_subject
     body    = step_instance.final_body
 
-    # Display name on the From header is the proposal owner's full
-    # name (Mike Frizzell), so the recipient sees
+    # Display name on the From header is the proposal owner's full name, so
+    # the recipient sees:
     #   "Mike Frizzell" <mike@servicemark.ai>
-    # instead of just the bare connected-mailbox address. Falls back
-    # to nil (no display name, just the email) if the owner has no
-    # name set on their profile.
+    # The bare email address comes from the originator's own Gmail
+    # delegation, not from a shared location/admin mailbox.
     from_name = host.owner&.full_name
 
     # The first email of the sequence carries the proposal's PDF
@@ -192,7 +213,7 @@ class CampaignSweepJob < ApplicationJob
     # to admins deleting and re-adding step 1.
     attachments = first_step?(step_instance) ? pdf_attachments_for(host) : []
 
-    sender = GmailSender.new(mailbox)
+    sender = GmailSender.new(delegation)
     send_response = sender.send_email(to: recipient, subject: subject, body: body.to_s, from_name: from_name, attachments: attachments)
     if send_response.nil?
       mark_failed(step_instance, instance)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,15 @@ class User < ApplicationRecord
 
   validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }, allow_blank: true
 
+  # The Gmail OAuth delegation a campaign send for this user (as a proposal
+  # originator) would authenticate as. Per PRD-09 v1.3 §1, customer email goes
+  # out from the originator's own Gmail — not from a shared location/admin
+  # mailbox — so this is what PreSendChecklist and CampaignSweepJob look up
+  # before each send. Returns nil when the originator has not connected Gmail.
+  def gmail_delegation
+    email_delegations.where(provider: "google").first
+  end
+
   def full_name
     [first_name, last_name].compact_blank.join(" ").presence
   end

--- a/app/services/gmail_sender.rb
+++ b/app/services/gmail_sender.rb
@@ -213,12 +213,22 @@ class GmailSender
   # Builds a multipart/mixed Mail::Message with a plain-text body and
   # one part per attachment hash. The Mail gem handles MIME boundaries,
   # base64 encoding of binary content, and Content-Disposition headers.
+  #
+  # Note: assigning to `msg.body=` and then adding attachments does NOT
+  # produce a usable text part — the body string is silently dropped from
+  # the encoded multipart output. We have to build the body as an explicit
+  # text/plain part. Once the first text_part is set, Mail promotes the
+  # message to multipart for us; subsequent attachments slot in cleanly.
   def build_multipart(to:, from:, subject:, body:, attachments:)
+    body_text = body.to_s
     msg = Mail.new
     msg.to      = to
     msg.from    = from
     msg.subject = subject
-    msg.body    = body
+    msg.text_part = Mail::Part.new do
+      content_type "text/plain; charset=UTF-8"
+      body body_text
+    end
     Array(attachments).each do |att|
       msg.attachments[att[:filename]] = {
         content:   att[:content],

--- a/app/services/pre_send_checklist.rb
+++ b/app/services/pre_send_checklist.rb
@@ -42,7 +42,7 @@ class PreSendChecklist
 
   def run
     [
-      check_mailbox_connected,
+      check_originator_mailbox,
       check_pipeline_stage,
       check_status_overlay,
       check_campaign_active,
@@ -67,18 +67,34 @@ class PreSendChecklist
 
   attr_reader :step_instance, :campaign_instance, :job_proposal
 
-  def check_mailbox_connected
-    mailbox = ApplicationMailbox.current
-    if mailbox.nil?
-      fail_check(:mailbox_connected, "Mailbox connected", BLOCK_DELIVERY_ISSUE,
-                 "No Gmail mailbox is connected for this tenant.",
-                 "Connect a mailbox in Settings → Integrations.")
-    elsif mailbox.expired? && mailbox.refresh_token.blank?
-      fail_check(:mailbox_connected, "Mailbox connected", BLOCK_DELIVERY_ISSUE,
-                 "The connected Gmail mailbox's authorization has expired and there is no refresh token.",
-                 "Reconnect the mailbox in Settings → Integrations.")
+  # Per PRD-09 v1.3 §1, customer email goes out from the originator's own
+  # Gmail (not from a shared location/admin mailbox), so the credential the
+  # sweep authenticates as is the proposal owner's EmailDelegation. A missing
+  # or unrecoverably-expired delegation surfaces as a delivery_issue on the
+  # job so the operator (or the originator) reconnects Gmail before the next
+  # step ships.
+  def check_originator_mailbox
+    label = "Originator's Gmail connected"
+    return missing_proposal(:originator_mailbox, label) if job_proposal.nil?
+
+    owner = job_proposal.owner
+    if owner.nil?
+      return fail_check(:originator_mailbox, label, BLOCK_DELIVERY_ISSUE,
+                        "This job has no owner — campaign emails have no originator to send from.",
+                        "Set an owner on the proposal before the campaign can ship.")
+    end
+
+    delegation = owner.gmail_delegation
+    if delegation.nil?
+      fail_check(:originator_mailbox, label, BLOCK_DELIVERY_ISSUE,
+                 "#{owner.display_name} has not connected their Gmail account, so there is no originator mailbox to send from.",
+                 "The originator must connect their Gmail in Settings → Integrations.")
+    elsif delegation.expired? && delegation.refresh_token.blank?
+      fail_check(:originator_mailbox, label, BLOCK_DELIVERY_ISSUE,
+                 "#{owner.display_name}'s Gmail authorization has expired and cannot be refreshed automatically.",
+                 "The originator must reconnect their Gmail in Settings → Integrations.")
     else
-      pass_check(:mailbox_connected, "Mailbox connected")
+      pass_check(:originator_mailbox, label)
     end
   end
 

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -258,7 +258,9 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     get job_proposal_url(jp)
     assert_response :success
     assert_select "h2", text: "Pre-send checklist"
-    assert_match "Mailbox connected", response.body
+    # The apostrophe in "Originator's Gmail connected" gets HTML-escaped in
+    # the rendered page, so match with a regex that doesn't care.
+    assert_match(/Originator(['&#39;]+s)? Gmail connected/, response.body)
     assert_match "Recipient email present and valid", response.body
     assert_match "Recipient is not on the suppression list", response.body
   end

--- a/test/jobs/campaign_sweep_job_test.rb
+++ b/test/jobs/campaign_sweep_job_test.rb
@@ -13,9 +13,6 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     @step_one = campaign_steps(:approved_step_one)
     @step_two = campaign_steps(:approved_step_two)
     @proposal = job_proposals(:in_users_org)
-    # status:approved is the operator-explicit "go" gate the sweep checks
-    # before sending. Existing tests pre-date this gate; default to approved
-    # and let any gate-specific tests below override.
     # status:approved gates operator approval. pipeline_stage:in_campaign
     # is the canonical PRD-09 §9.2 check-2 condition for a job that has
     # been launched into a campaign — fixtures don't set it explicitly,
@@ -28,6 +25,19 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
       customer_street: "Oak Ridge"
     )
     @instance = CampaignInstance.create!(campaign: @campaign, host: @proposal, status: :active)
+
+    # Per PRD-09 §1, customer email goes out from the originator's own Gmail.
+    # The pre-send checklist's originator_mailbox check requires this — set
+    # it up by default and let tests opt out (delete it, expire it) to
+    # exercise the failure paths.
+    @owner_delegation = EmailDelegation.create!(
+      user: @proposal.owner,
+      provider: "google",
+      email: "originator@example.com",
+      access_token: "atk",
+      refresh_token: "rtk",
+      expires_at: 1.hour.from_now
+    )
 
     # Existing tests assume mail goes out. The send gates require either
     # production OR TEST_TO_EMAIL set, so default tests to redirect-mode
@@ -72,9 +82,9 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     assert_equal 1, GmailSender.deliveries.size
     delivery = GmailSender.deliveries.first
     assert_equal "redirect@test.example.com", delivery[:to]
-    # From header carries the proposal owner's display name when set,
-    # otherwise just the bare connected-mailbox email.
-    expected_from = @proposal.owner.full_name.present? ? %("#{@proposal.owner.full_name}" <ops@example.com>) : "ops@example.com"
+    # From header is the originator's own Gmail (per PRD-09 §1) with their
+    # display name attached when set — not the shared ApplicationMailbox.
+    expected_from = @proposal.owner.full_name.present? ? %("#{@proposal.owner.full_name}" <originator@example.com>) : "originator@example.com"
     assert_equal expected_from, delivery[:from]
     assert_equal @step_one.template_subject, delivery[:subject]
   end
@@ -87,7 +97,20 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
 
     assert_equal "sent", step_instance.reload.email_delivery_status
     assert_equal 1, GmailSender.deliveries.size
-    assert_equal %("Mike Frizzell" <ops@example.com>), GmailSender.deliveries.first[:from]
+    assert_equal %("Mike Frizzell" <originator@example.com>), GmailSender.deliveries.first[:from]
+  end
+
+  test "From email is the originator's Gmail, not the shared ApplicationMailbox" do
+    step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
+
+    CampaignSweepJob.new.perform
+
+    assert_equal "sent", step_instance.reload.email_delivery_status
+    delivery = GmailSender.deliveries.first
+    assert_includes delivery[:from], "originator@example.com",
+      "campaign mail must be sent from the originator's own Gmail"
+    refute_includes delivery[:from], "ops@example.com",
+      "campaign mail must NOT be sent from the shared ApplicationMailbox"
   end
 
   test "in production with no TEST_TO_EMAIL, mail goes to the customer's address" do
@@ -292,11 +315,11 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     assert_nil step_instance.gmail_thread_snapshot
   end
 
-  test "in production with no mailbox, the checklist surfaces a delivery issue on every queued step" do
-    # Per PRD-09 §10.1 a disconnected mailbox is a delivery_issue, not a
-    # silent skip. The checklist's mailbox check fires first; the step is
-    # marked failed and the campaign run is stopped.
-    @mailbox.destroy!
+  test "in production, a missing originator Gmail surfaces a delivery issue on the step" do
+    # Per PRD-09 §10.1 a disconnected originator Gmail is a delivery_issue,
+    # not a silent skip. The checklist's originator-mailbox check fires
+    # first; the step is marked failed and the campaign run is stopped.
+    @owner_delegation.destroy!
     step_instance = build_step_instance(@step_one, status: :pending, due: 1.minute.ago)
 
     with_production_environment(true) { CampaignSweepJob.new.perform }

--- a/test/services/gmail_sender_test.rb
+++ b/test/services/gmail_sender_test.rb
@@ -52,4 +52,29 @@ class GmailSenderTest < ActiveSupport::TestCase
     delivery = GmailSender.deliveries.last
     assert_equal [], delivery[:attachments]
   end
+
+  # Regression: a multipart message used to drop the body string entirely.
+  # `msg.body = "..."` followed by `msg.attachments[...] = {...}` produced a
+  # multipart/mixed message with only the attachment part — recipients saw
+  # an empty email body next to the PDF. Build the body as an explicit
+  # text/plain part so it survives the multipart promotion.
+  test "build_multipart includes the body as a text/plain part alongside attachments" do
+    sender = GmailSender.new(@mailbox)
+    msg = sender.send(:build_multipart,
+      to: "alice@example.com",
+      from: "bob@example.com",
+      subject: "Test",
+      body: "Hello there. This is the body.",
+      attachments: [{ filename: "p.pdf", content: "%PDF-1.4 fake", mime_type: "application/pdf" }]
+    )
+
+    encoded = msg.encoded
+    assert_includes encoded, "Hello there. This is the body.",
+      "the message body must appear in the encoded multipart output"
+    assert_includes encoded, "Content-Type: text/plain"
+    assert_includes encoded, "Content-Type: application/pdf"
+    assert_match(/Content-Disposition: attachment;\s+filename=p\.pdf/, encoded)
+    refute_nil msg.text_part, "multipart message must have a text part"
+    assert_equal "Hello there. This is the body.", msg.text_part.body.decoded
+  end
 end

--- a/test/services/pre_send_checklist_test.rb
+++ b/test/services/pre_send_checklist_test.rb
@@ -2,13 +2,6 @@ require "test_helper"
 
 class PreSendChecklistTest < ActiveSupport::TestCase
   setup do
-    @mailbox = ApplicationMailbox.create!(
-      provider: "google",
-      email: "ops@example.com",
-      access_token: "atk",
-      refresh_token: "rtk",
-      expires_at: 1.hour.from_now
-    )
     @campaign = campaigns(:approved_campaign)
     @step = campaign_steps(:approved_step_one)
     @proposal = job_proposals(:in_users_org)
@@ -19,6 +12,15 @@ class PreSendChecklistTest < ActiveSupport::TestCase
       customer_email: "alice@example.com",
       customer_house_number: "100",
       customer_street: "Oak Ridge"
+    )
+    # Per PRD-09 §1, the campaign sends as the originator's own Gmail.
+    @owner_delegation = EmailDelegation.create!(
+      user: @proposal.owner,
+      provider: "google",
+      email: "originator@example.com",
+      access_token: "atk",
+      refresh_token: "rtk",
+      expires_at: 1.hour.from_now
     )
     @instance = CampaignInstance.create!(campaign: @campaign, host: @proposal, status: :active)
     @step_instance = CampaignStepInstance.create!(
@@ -41,36 +43,37 @@ class PreSendChecklistTest < ActiveSupport::TestCase
   test "labels are operator-friendly" do
     checks = PreSendChecklist.run(@step_instance)
 
-    assert_match(/mailbox/i, checks.find { |c| c.key == :mailbox_connected }.label)
+    assert_match(/originator/i, checks.find { |c| c.key == :originator_mailbox }.label)
     assert_match(/recipient/i, checks.find { |c| c.key == :contact_email }.label)
     assert_match(/suppression/i, checks.find { |c| c.key == :suppression }.label)
   end
 
-  test "fails the mailbox check with a delivery_issue when no mailbox is connected" do
-    @mailbox.destroy!
+  test "fails originator_mailbox with delivery_issue when the proposal owner has no Gmail delegation" do
+    @owner_delegation.destroy!
 
     blocker = PreSendChecklist.new(@step_instance).first_blocker
 
-    assert_equal :mailbox_connected, blocker.key
+    assert_equal :originator_mailbox, blocker.key
     assert blocker.block_delivery_issue?
-    assert_match(/no Gmail mailbox/i, blocker.detail)
+    assert_match(/has not connected their Gmail/i, blocker.detail)
   end
 
-  test "fails the mailbox check with delivery_issue when the token is expired and there is no refresh token" do
-    @mailbox.update!(refresh_token: nil, expires_at: 1.hour.ago)
+  test "fails originator_mailbox with delivery_issue when the delegation is expired and has no refresh token" do
+    @owner_delegation.update!(refresh_token: nil, expires_at: 1.hour.ago)
 
     blocker = PreSendChecklist.new(@step_instance).first_blocker
 
-    assert_equal :mailbox_connected, blocker.key
+    assert_equal :originator_mailbox, blocker.key
     assert blocker.block_delivery_issue?
+    assert_match(/expired/i, blocker.detail)
   end
 
-  test "passes the mailbox check when an expired token still has a refresh token" do
-    @mailbox.update!(refresh_token: "rtk", expires_at: 1.hour.ago)
+  test "passes originator_mailbox when an expired delegation still has a refresh token" do
+    @owner_delegation.update!(refresh_token: "rtk", expires_at: 1.hour.ago)
 
     checks = PreSendChecklist.run(@step_instance)
 
-    assert checks.find { |c| c.key == :mailbox_connected }.pass?
+    assert checks.find { |c| c.key == :originator_mailbox }.pass?
   end
 
   test "fails pipeline_stage with block_silent when the proposal status is not approved" do


### PR DESCRIPTION
Two bugs the user spotted while reviewing yesterday's send:

1. Customer email was leaving from the shared ApplicationMailbox (location/admin account) when per PRD-09 §1 it must be sent from the proposal originator's own Gmail. CampaignSweepJob now resolves the credential per-step from `host.owner.gmail_delegation` and the PreSendChecklist's first check enforces the same — a missing or unrecoverably-expired delegation surfaces as Action needed on the job. ApplicationMailbox stays in the picture only as a "real-send environment is configured" sentinel for mode resolution and as the sender for transactional Devise / invitation mail.

2. A multipart send dropped the body. `Mail#body=` followed by `Mail#attachments[...]` promoted the message to multipart but lost the body string — recipients saw a PDF with an empty email next to it. Build the body as an explicit text/plain `Mail::Part` so it survives the promotion. Regression test added.

fixes #195 and #194