### PR TITLE
campaign_instance: show originator's Gmail on the approval preview

### DIFF
--- a/app/controllers/campaign_instances_controller.rb
+++ b/app/controllers/campaign_instances_controller.rb
@@ -12,7 +12,12 @@ class CampaignInstancesController < ApplicationController
   before_action :load_proposal_and_instance
 
   def show
-    @from_address = ApplicationMailbox.current&.email
+    # Per PRD-09 §1, the campaign sends as the proposal originator's own
+    # Gmail — not the shared ApplicationMailbox — so the preview reflects
+    # the originator's delegation, falling back to nil when they haven't
+    # connected Gmail yet (which the pre-send checklist will block on).
+    @from_owner   = @job_proposal.owner
+    @from_address = @from_owner&.gmail_delegation&.email
     @to_address   = @job_proposal.customer_email.presence
 
     step_instances = @campaign_instance.step_instances

--- a/app/views/campaign_instances/show.html.erb
+++ b/app/views/campaign_instances/show.html.erb
@@ -42,9 +42,14 @@
       <dd class="col-sm-10">
         <% if @from_address %>
           <code><%= @from_address %></code>
-          <span class="text-muted small ms-2">(connected application mailbox)</span>
+          <span class="text-muted small ms-2">
+            (<%= @from_owner.display_name %>'s connected Gmail)
+          </span>
         <% else %>
-          <span class="text-warning">No application mailbox connected — in development the sweep job runs in FAKE-SEND mode and skips the real Gmail call.</span>
+          <span class="text-warning">
+            <%= @from_owner&.display_name || "The proposal owner" %>
+            has not connected their Gmail yet — the pre-send checklist will block this campaign until they do.
+          </span>
         <% end %>
       </dd>
 

--- a/test/controllers/campaign_instances_controller_test.rb
+++ b/test/controllers/campaign_instances_controller_test.rb
@@ -117,6 +117,39 @@ class CampaignInstancesControllerTest < ActionDispatch::IntegrationTest
     refute_match admin_campaign_path(@campaign), response.body
   end
 
+  test "From line shows the originator's connected Gmail, not the shared application mailbox" do
+    ApplicationMailbox.create!(
+      provider: "google", email: "ops@example.com", access_token: "atk", expires_at: 1.hour.from_now
+    )
+    EmailDelegation.create!(
+      user: @proposal.owner,
+      provider: "google",
+      email: "originator@example.com",
+      access_token: "atk",
+      refresh_token: "rtk",
+      expires_at: 1.hour.from_now
+    )
+
+    sign_in @user
+    get job_proposal_campaign_instance_url(@proposal, @instance)
+
+    assert_response :success
+    assert_match "originator@example.com", response.body
+    refute_match "ops@example.com", response.body, "campaign mail must NOT be sent from the shared ApplicationMailbox"
+    refute_match "connected application mailbox", response.body
+  end
+
+  test "From line warns when the originator has not connected Gmail" do
+    @proposal.owner.update!(first_name: "Alice", last_name: "Owner")
+
+    sign_in @user
+    get job_proposal_campaign_instance_url(@proposal, @instance)
+
+    assert_response :success
+    assert_match "Alice Owner", response.body
+    assert_match "has not connected their Gmail yet", response.body
+  end
+
   test "previews send times anchored to now when JobProposal is not yet approved" do
     @step_one.update!(offset_min: 60)
     @step_two.update!(offset_min: 1440)


### PR DESCRIPTION
The pre-approval preview still labelled the From line as the connected ApplicationMailbox ("mike@servicemark.ai (connected application mailbox)") even though the actual send now goes from the originator's own Gmail. Pull the address from owner.gmail_delegation and rephrase the parenthetical so the operator reviewing the campaign sees the account the email will actually leave from. The empty-state copy now points at the originator-mailbox checklist rule instead of FAKE-SEND.