### PR TITLE
gmail_delegation: accept both 'google_oauth2' and 'google' provider s…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,20 @@ class User < ApplicationRecord
 
   validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }, allow_blank: true
 
+  # All provider strings this app uses for Google delegations. OmniAuth's
+  # Google strategy registers itself as `google_oauth2` (what
+  # EmailDelegationsController persists today), but seeds and older fixtures
+  # in the wild use the shorter `google`. Match either so a delegation an
+  # operator already has connected isn't ignored on a string-mismatch.
+  GOOGLE_PROVIDERS = %w[google_oauth2 google].freeze
+
   # The Gmail OAuth delegation a campaign send for this user (as a proposal
   # originator) would authenticate as. Per PRD-09 v1.3 §1, customer email goes
   # out from the originator's own Gmail — not from a shared location/admin
   # mailbox — so this is what PreSendChecklist and CampaignSweepJob look up
   # before each send. Returns nil when the originator has not connected Gmail.
   def gmail_delegation
-    email_delegations.where(provider: "google").first
+    email_delegations.where(provider: GOOGLE_PROVIDERS).first
   end
 
   def full_name

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -84,7 +84,7 @@
                 <% end %>
               </td>
               <td>
-                <% gmail_delegation = user.email_delegations.find { |d| d.provider == "google" } %>
+                <% gmail_delegation = user.gmail_delegation %>
                 <% if gmail_delegation %>
                   <span class="badge text-bg-success">Linked</span>
                   <div class="text-muted small"><%= gmail_delegation.email %></div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -60,7 +60,7 @@
                   <% end %>
                 </td>
                 <td>
-                  <% gmail_delegation = user.email_delegations.find { |d| d.provider == "google" } %>
+                  <% gmail_delegation = user.gmail_delegation %>
                   <% if gmail_delegation %>
                     <span class="badge text-bg-success">Linked</span>
                     <div class="text-muted small"><%= gmail_delegation.email %></div>

--- a/test/controllers/campaign_instances_controller_test.rb
+++ b/test/controllers/campaign_instances_controller_test.rb
@@ -119,11 +119,11 @@ class CampaignInstancesControllerTest < ActionDispatch::IntegrationTest
 
   test "From line shows the originator's connected Gmail, not the shared application mailbox" do
     ApplicationMailbox.create!(
-      provider: "google", email: "ops@example.com", access_token: "atk", expires_at: 1.hour.from_now
+      provider: "google_oauth2", email: "ops@example.com", access_token: "atk", expires_at: 1.hour.from_now
     )
     EmailDelegation.create!(
       user: @proposal.owner,
-      provider: "google",
+      provider: "google_oauth2",
       email: "originator@example.com",
       access_token: "atk",
       refresh_token: "rtk",

--- a/test/jobs/campaign_sweep_job_test.rb
+++ b/test/jobs/campaign_sweep_job_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class CampaignSweepJobTest < ActiveSupport::TestCase
   setup do
     @mailbox = ApplicationMailbox.create!(
-      provider: "google",
+      provider: "google_oauth2",
       email: "ops@example.com",
       access_token: "atk",
       refresh_token: "rtk",
@@ -32,7 +32,7 @@ class CampaignSweepJobTest < ActiveSupport::TestCase
     # exercise the failure paths.
     @owner_delegation = EmailDelegation.create!(
       user: @proposal.owner,
-      provider: "google",
+      provider: "google_oauth2",
       email: "originator@example.com",
       access_token: "atk",
       refresh_token: "rtk",

--- a/test/services/pre_send_checklist_test.rb
+++ b/test/services/pre_send_checklist_test.rb
@@ -16,7 +16,7 @@ class PreSendChecklistTest < ActiveSupport::TestCase
     # Per PRD-09 §1, the campaign sends as the originator's own Gmail.
     @owner_delegation = EmailDelegation.create!(
       user: @proposal.owner,
-      provider: "google",
+      provider: "google_oauth2",
       email: "originator@example.com",
       access_token: "atk",
       refresh_token: "rtk",


### PR DESCRIPTION
…trings

The originator-mailbox lookup hard-coded `provider: "google"`, but the real OAuth callback in EmailDelegationsController persists `auth.provider`, which OmniAuth's Google strategy reports as `google_oauth2`. That meant a connected Gmail showed up correctly on the profile page (which renders straight from the row) yet the pre-send checklist and the campaign preview's From line both read "has not connected their Gmail yet" — because their lookup missed the row.

Match either string so an existing connection is honored regardless of which value was written, and centralize the constant on User so the profile/team views agree with PreSendChecklist and CampaignSweepJob. The team and admin user-list views now read through `User#gmail_delegation` instead of duplicating the provider check.