### PR TITLE
Scope the customer-replied stop; let originators resume after a reply

### DIFF
--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -113,19 +113,30 @@ class JobProposalsController < ApplicationController
     set_form_options
   end
 
+  # Operator-driven resume. A campaign reaches a stopped state two ways an
+  # operator can walk back: a manual pause, or an automatic stop when the
+  # customer replied. "Customer waiting" is not terminal — once the
+  # operator has handled the reply in Gmail they can put the proposal back
+  # into the automated campaign. The inverse flow is `pause`.
   def resume
     instance = @job_proposal.campaign_instances.order(created_at: :desc).first
 
-    if instance&.status_paused?
+    if instance&.status_paused? || instance&.status_stopped_on_reply?
       JobProposal.transaction do
+        # A campaign that stopped on a customer reply still has that reply
+        # sitting in its Gmail thread. Fold it into the step snapshot so
+        # the reply poller treats it as baseline — otherwise the next tick
+        # would re-detect the same reply and stop the campaign again.
+        absorb_recorded_replies(instance) if instance.status_stopped_on_reply?
         # ended_at cleared so the reply poller's age cutoff treats this as
-        # a live campaign again (was set when pause stopped the instance).
+        # a live campaign again (was set when the campaign stopped).
         instance.update!(status: :active, ended_at: nil)
         @job_proposal.update!(status_overlay: nil)
       end
       redirect_to job_proposal_path(@job_proposal), notice: "Campaign resumed."
     else
-      redirect_to job_proposal_path(@job_proposal), alert: "This campaign isn't paused."
+      redirect_to job_proposal_path(@job_proposal),
+        alert: "This campaign isn't paused or waiting on a customer reply."
     end
   end
 
@@ -310,6 +321,27 @@ class JobProposalsController < ApplicationController
   end
 
   private
+
+  # Resuming a campaign that stopped on a customer reply must not let the
+  # reply poller re-trip on that same reply. Each step the poller flagged
+  # carries the exact Gmail message in gmail_reply_payload; appending it to
+  # the step's send-time thread snapshot makes that message part of the new
+  # baseline, so only a *further* reply restarts the stop. Steps with no
+  # usable snapshot are simply unflagged — a blank snapshot makes the poller
+  # re-baseline from the live thread on its next pass anyway.
+  def absorb_recorded_replies(instance)
+    instance.step_instances.where(customer_replied: true).find_each do |step|
+      snapshot = step.gmail_thread_snapshot
+      payload = step.gmail_reply_payload
+      if payload.present? && snapshot.is_a?(Hash) && snapshot["messages"].is_a?(Array)
+        merged = snapshot.deep_dup
+        merged["messages"] << payload
+        step.update!(gmail_thread_snapshot: merged, customer_replied: false)
+      else
+        step.update!(customer_replied: false)
+      end
+    end
+  end
 
   def lock_in_instance!(instance)
     started_at = Time.current

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,10 +17,12 @@ class UsersController < ApplicationController
         Invitation.none
       end
       @invite_locations = @tenant.locations.active.order(:display_name)
+      @reply_ignored_domains = @tenant.reply_ignored_domains
     else
       @users = User.none
       @pending_invitations = Invitation.none
       @invite_locations = Location.none
+      @reply_ignored_domains = []
     end
     @invitation = Invitation.new
   end

--- a/app/jobs/gmail_reply_poll_job.rb
+++ b/app/jobs/gmail_reply_poll_job.rb
@@ -25,6 +25,12 @@ require "net/http"
 #     header whose address isn't the originator's Gmail, that message is
 #     either a customer reply or an asynchronous bounce DSN.
 #
+# A new message from the originator's own organization (a CC'd
+# teammate, an owner forwarding the thread internally) or from
+# ServiceMark AI staff is not a customer reply — see
+# Tenant#reply_ignored_domains — and is skipped so the scan can find a
+# genuine customer reply further down the thread.
+#
 # Bounces are distinguished by the local-part of the inbound From
 # address (mailer-daemon, postmaster). The handling diverges:
 #   - Customer reply  -> CampaignInstance :stopped_on_reply,
@@ -109,7 +115,14 @@ class GmailReplyPollJob < ApplicationJob
       return
     end
 
-    inbound = first_inbound_message(thread, step_instance.gmail_thread_snapshot, delegation.email)
+    # The customer-replied stop is meant to fire on a *customer* reply
+    # only. Mail that comes back from the originator's own organization
+    # (a CC'd teammate, an owner forwarding internally) or from
+    # ServiceMark AI staff is not a customer reply — see
+    # Tenant#reply_ignored_domains. Bounces are unaffected: a DSN is
+    # caught earlier by its mailer-daemon/postmaster local-part.
+    tenant = step_instance.campaign_instance.host&.owner&.tenant
+    inbound = first_inbound_message(thread, step_instance.gmail_thread_snapshot, delegation.email, tenant)
     return unless inbound
 
     case inbound[:kind]
@@ -127,7 +140,7 @@ class GmailReplyPollJob < ApplicationJob
   # message itself — rather than just a flag — lets the caller persist
   # the specific Gmail payload that triggered the stop, useful for
   # diagnostics.
-  def first_inbound_message(current_thread, baseline_thread, originator_email)
+  def first_inbound_message(current_thread, baseline_thread, originator_email, tenant)
     baseline_count = Array(baseline_thread["messages"]).length
     current_messages = Array(current_thread["messages"])
     return nil if current_messages.length <= baseline_count
@@ -135,9 +148,23 @@ class GmailReplyPollJob < ApplicationJob
     new_messages = current_messages.last(current_messages.length - baseline_count)
     new_messages.each do |msg|
       next unless from_other_party?(msg, originator_email)
-      return { kind: bounce_message?(msg) ? :bounce : :reply, message: msg }
+      return { kind: :bounce, message: msg } if bounce_message?(msg)
+      # An internal reply (tenant's own domain / ServiceMark AI) isn't a
+      # customer reply — skip it and keep scanning later messages for a
+      # genuine customer reply further down the thread.
+      next if internal_reply?(msg, tenant)
+      return { kind: :reply, message: msg }
     end
     nil
+  end
+
+  # True when the message's From address belongs to a domain whose
+  # replies should not trip the customer-replied stop. With no tenant we
+  # can't resolve the tenant's own domains, so nothing is treated as
+  # internal.
+  def internal_reply?(message, tenant)
+    return false if tenant.nil?
+    tenant.reply_ignored_sender?(extract_email(extract_from_header(message)))
   end
 
   def from_other_party?(message, originator_email)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,4 +1,9 @@
 class Tenant < ApplicationRecord
+  # ServiceMark AI's own email domain. Replies from this domain are
+  # platform staff, never the customer, so they never stop a campaign —
+  # see #reply_ignored_domains. Always present regardless of tenant.
+  SERVICEMARK_DOMAIN = "servicemark.ai".freeze
+
   has_many :locations, dependent: :destroy
   has_many :users, dependent: :nullify
   has_many :job_proposals, dependent: :destroy
@@ -35,5 +40,39 @@ class Tenant < ApplicationRecord
   def logo_image_url
     return Rails.application.routes.url_helpers.rails_blob_url(logo, only_path: true) if logo.attached?
     logo_url.presence
+  end
+
+  # The account's owners: tenant users not pinned to a single location
+  # (the same population that carries the tenant-admin role). Their email
+  # addresses define what counts as "the tenant's own domain".
+  def owner_users
+    users.where(location_id: nil)
+  end
+
+  # A campaign stops automatically when the *customer* replies. Mail that
+  # comes back from the business's own people — a teammate CC'd on the
+  # thread, an owner forwarding it internally — is not a customer reply
+  # and must not stop the campaign. The same goes for ServiceMark AI staff.
+  #
+  # This returns the email domains whose replies are ignored for that
+  # purpose: the tenant's own domains (derived from the email addresses of
+  # #owner_users) plus the platform domain. Downcased and de-duped.
+  def reply_ignored_domains
+    owner_domains = owner_users.pluck(:email).filter_map { |email| self.class.email_domain(email) }
+    (owner_domains << SERVICEMARK_DOMAIN).uniq
+  end
+
+  # True when a reply from `email` should NOT stop a campaign because it
+  # came from this tenant's own domain or from ServiceMark AI.
+  def reply_ignored_sender?(email)
+    domain = self.class.email_domain(email)
+    domain.present? && reply_ignored_domains.include?(domain)
+  end
+
+  # Extracts the lowercased domain from an email address, or nil when the
+  # value has no usable domain part.
+  def self.email_domain(email)
+    domain = email.to_s.split("@", 2)[1]
+    domain&.strip&.downcase.presence
   end
 end

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -28,15 +28,22 @@
             data-bs-toggle="modal" data-bs-target="#markLostModal">
       Mark Lost
     </button>
-    <%# Pause only makes sense while a CampaignInstance is actively
-        running. A completed run (all steps shipped) or a terminal-stopped
-        run (delivery_issue, customer_reply, etc.) has nothing to pause. %>
+    <%# Pause only makes sense while a campaign is actively running. A
+        campaign that stopped itself when the customer replied isn't
+        finished — "customer waiting" is a hand-off, not an ending — so it
+        gets a Resume button instead, for once the operator has answered. %>
     <% latest_instance = @job_proposal.campaign_instances.order(created_at: :desc).first %>
     <% if latest_instance&.status_active? %>
       <%= button_to "Pause", pause_job_proposal_path(@job_proposal),
             method: :patch,
             class: "btn btn-outline-warning btn-sm",
             form: { class: "d-inline" } %>
+    <% elsif latest_instance&.status_stopped_on_reply? %>
+      <%= button_to "Resume campaign", resume_job_proposal_path(@job_proposal),
+            method: :patch,
+            class: "btn btn-outline-success btn-sm",
+            form: { class: "d-inline", data: { turbo_confirm: "The customer replied and the campaign paused itself. Resume sending the remaining emails?" } },
+            title: "Resume the marketing campaign once you've answered the customer." %>
     <% end %>
   <% end %>
   <%# Soft delete. SMAI staff and tenant admins can both do this — see

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -129,6 +129,27 @@
     </div>
   <% end %>
 
+  <div class="card shadow-sm mt-4">
+    <div class="card-header">
+      <h3 class="h6 mb-0">Ignored reply domains</h3>
+    </div>
+    <div class="card-body">
+      <p class="text-muted small mb-3">
+        A marketing campaign stops on its own as soon as the customer replies.
+        Replies from the domains below are treated as internal — your own team,
+        or ServiceMark AI — so they won't stop a running campaign. Your team's
+        domains come from the email addresses of your account admins above.
+      </p>
+      <% if @reply_ignored_domains.any? %>
+        <% @reply_ignored_domains.each do |domain| %>
+          <span class="badge text-bg-light border me-1 mb-1">@<%= domain %></span>
+        <% end %>
+      <% else %>
+        <span class="text-muted small">No domains are being ignored yet.</span>
+      <% end %>
+    </div>
+  </div>
+
   <% if current_user.can_invite_into_tenant? %>
   <div class="modal fade" id="inviteUserModal" tabindex="-1" aria-labelledby="inviteUserModalLabel" aria-hidden="true">
     <div class="modal-dialog">

--- a/docs/user-guide/04-campaign-maintenance.md
+++ b/docs/user-guide/04-campaign-maintenance.md
@@ -71,7 +71,10 @@ What you'll see on the **Jobs** board:
 What to do:
 
 1. **Click Open in Gmail** on the job's card. Read the full thread and respond.
-2. **When the deal is decided**, mark the job won or lost ([§4e](#4e-marking-a-job-as-won--lost)).
+2. **If the deal is decided**, mark the job won or lost ([§4e](#4e-marking-a-job-as-won--lost)).
+3. **If the conversation should keep going** — the customer had a question, you've answered it, and you still want the automated follow-ups — open the job's detail page and click **Resume campaign** in the top action bar. The remaining steps pick back up on their cadence. The reply you just handled won't stop the campaign a second time; only a *new* reply will.
+
+> *Waiting on the customer* is a hand-off, not an ending — the campaign is paused for you, not finished. Resume it whenever the job should go back to chasing a response.
 
 > **Delivery problem instead of a reply?** If the campaign couldn't deliver an email (bad address, the customer's mailbox bounced it), the action button reads **Fix delivery issue**. Click it to open the job's edit page and correct the customer's email address. *Restarting the campaign from a delivery problem is not yet built* ([#117](https://github.com/frizman21/smai-server/issues/117)) — for now, ask an admin.
 

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -289,6 +289,20 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Alice", response.body
   end
 
+  test "show offers a Resume campaign button when the campaign stopped on a customer reply" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: "in_campaign", status_overlay: "customer_waiting")
+    CampaignInstance.create!(host: jp, campaign: campaigns(:approved_campaign), status: :stopped_on_reply)
+
+    get job_proposal_url(jp)
+    assert_response :success
+    assert_select "form[action=?][method=post]", resume_job_proposal_path(jp) do
+      assert_select "input[name='_method'][value=patch]"
+    end
+    assert_match(/Resume campaign/i, response.body)
+  end
+
   test "show returns 404 for a proposal outside the user's scope (no info leak)" do
     sign_in @user
     other_jp = job_proposals(:other_tenant)
@@ -852,6 +866,53 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     patch resume_job_proposal_url(jp)
     assert_redirected_to job_proposal_path(jp)
     assert_match(/isn't paused/i, flash[:alert])
+  end
+
+  test "resume flips a campaign stopped on a customer reply back to active and clears the overlay" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: "in_campaign", status_overlay: "customer_waiting")
+    instance = CampaignInstance.create!(
+      host: jp, campaign: campaigns(:approved_campaign),
+      status: :stopped_on_reply, ended_at: 1.day.ago
+    )
+
+    patch resume_job_proposal_url(jp)
+    assert_redirected_to job_proposal_path(jp)
+    assert_match(/Campaign resumed/i, flash[:notice])
+
+    instance.reload
+    assert instance.status_active?
+    assert_nil instance.ended_at, "ended_at is cleared so the reply poller treats it as live again"
+    assert_nil jp.reload.status_overlay
+  end
+
+  test "resume folds the recorded customer reply into the step snapshot so the poller won't re-stop" do
+    sign_in @user
+    jp = job_proposals(:in_users_org)
+    jp.update!(pipeline_stage: "in_campaign", status_overlay: "customer_waiting")
+    instance = CampaignInstance.create!(
+      host: jp, campaign: campaigns(:approved_campaign), status: :stopped_on_reply
+    )
+    reply = { "id" => "reply-1", "payload" => { "headers" => [] } }
+    step = CampaignStepInstance.create!(
+      campaign_instance: instance,
+      campaign_step: campaign_steps(:approved_step_one),
+      planned_delivery_at: 1.hour.ago,
+      email_delivery_status: :sent,
+      final_subject: "s", final_body: "b",
+      gmail_thread_id: "t1",
+      gmail_thread_snapshot: { "id" => "t1", "messages" => [{ "id" => "sent-1" }] },
+      customer_replied: true,
+      gmail_reply_payload: reply
+    )
+
+    patch resume_job_proposal_url(jp)
+
+    step.reload
+    assert_not step.customer_replied, "step is unflagged once the reply is absorbed"
+    assert_equal %w[sent-1 reply-1], step.gmail_thread_snapshot["messages"].map { |m| m["id"] },
+      "the recorded reply becomes part of the baseline snapshot"
   end
 
   # --- launch_campaign (manual relaunch from the show page) ---------------

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -104,6 +104,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_match "Originator", response.body
   end
 
+  test "lists the ignored reply domains for the tenant" do
+    sign_in @user
+    get users_url
+    assert_response :success
+    assert_match(/Ignored reply domains/i, response.body)
+    # @user is the account owner (no location); its email domain is the
+    # tenant's own domain, alongside the platform domain.
+    assert_match "@example.com", response.body
+    assert_match "@servicemark.ai", response.body
+  end
+
   # --- edit / update ------------------------------------------------------
 
   test "edit redirects to sign-in when not signed in" do

--- a/test/jobs/gmail_reply_poll_job_test.rb
+++ b/test/jobs/gmail_reply_poll_job_test.rb
@@ -86,6 +86,25 @@ class GmailReplyPollJobTest < ActiveSupport::TestCase
     assert_equal "active", @instance.reload.status
   end
 
+  test "stops on a reply from any third party on a non-excluded domain" do
+    # The customer's wife forwards the thread to her husband's work email;
+    # he replies to the thread with our originator still on it. His domain
+    # is neither the tenant's nor servicemark.ai, so this is a real reply
+    # and must stop the campaign.
+    snapshot = outgoing_only("t1")
+    step = build_sent_step(thread_id: "t1", snapshot_messages: snapshot)
+    reply = message_from("husband@some-employer.com", "t1")
+    current = snapshot + [reply]
+
+    stub_fetch_thread(returns: { "id" => "t1", "messages" => current }) do
+      GmailReplyPollJob.new.perform
+    end
+
+    assert_equal "stopped_on_reply", @instance.reload.status
+    assert_equal "customer_waiting", @proposal.reload.status_overlay
+    assert_equal reply, step.reload.gmail_reply_payload
+  end
+
   test "ignores a reply that comes from the originator's own tenant domain" do
     # The proposal owner belongs to tenant :one, whose account owner is
     # one@example.com — so example.com is the tenant's own domain.

--- a/test/jobs/gmail_reply_poll_job_test.rb
+++ b/test/jobs/gmail_reply_poll_job_test.rb
@@ -86,6 +86,50 @@ class GmailReplyPollJobTest < ActiveSupport::TestCase
     assert_equal "active", @instance.reload.status
   end
 
+  test "ignores a reply that comes from the originator's own tenant domain" do
+    # The proposal owner belongs to tenant :one, whose account owner is
+    # one@example.com — so example.com is the tenant's own domain.
+    snapshot = outgoing_only("t1")
+    build_sent_step(thread_id: "t1", snapshot_messages: snapshot)
+    internal = message_from("colleague@example.com", "t1")
+    current = snapshot + [internal]
+
+    stub_fetch_thread(returns: { "id" => "t1", "messages" => current }) do
+      GmailReplyPollJob.new.perform
+    end
+
+    assert_equal "active", @instance.reload.status, "an internal teammate reply must not stop the campaign"
+    assert_nil @proposal.reload.status_overlay
+  end
+
+  test "ignores a reply that comes from the servicemark.ai domain" do
+    snapshot = outgoing_only("t1")
+    build_sent_step(thread_id: "t1", snapshot_messages: snapshot)
+    current = snapshot + [message_from("staff@servicemark.ai", "t1")]
+
+    stub_fetch_thread(returns: { "id" => "t1", "messages" => current }) do
+      GmailReplyPollJob.new.perform
+    end
+
+    assert_equal "active", @instance.reload.status, "a ServiceMark AI reply must not stop the campaign"
+  end
+
+  test "stops on a genuine customer reply even when an internal reply precedes it" do
+    snapshot = outgoing_only("t1")
+    step = build_sent_step(thread_id: "t1", snapshot_messages: snapshot)
+    internal = message_from("colleague@example.com", "t1")
+    reply = message_from("customer@elsewhere.com", "t1")
+    current = snapshot + [internal, reply]
+
+    stub_fetch_thread(returns: { "id" => "t1", "messages" => current }) do
+      GmailReplyPollJob.new.perform
+    end
+
+    assert_equal "stopped_on_reply", @instance.reload.status
+    assert_equal "customer_waiting", @proposal.reload.status_overlay
+    assert_equal reply, step.reload.gmail_reply_payload, "the customer reply, not the internal one, should trip the stop"
+  end
+
   test "establishes a baseline snapshot on first pass when send-time snapshot was missing" do
     step = build_sent_step(thread_id: "t1", snapshot_messages: nil)
     snapshot_now = outgoing_only("t1")

--- a/test/models/tenant_test.rb
+++ b/test/models/tenant_test.rb
@@ -52,4 +52,65 @@ class TenantTest < ActiveSupport::TestCase
     assert_match(/rails\/active_storage\/blobs/, tenant.logo_image_url)
     refute_match(/manual.png/, tenant.logo_image_url)
   end
+
+  # --- reply-ignored domains ---------------------------------------------
+
+  test "email_domain extracts the lowercased domain" do
+    assert_equal "acme.com", Tenant.email_domain("Owner@Acme.com")
+    assert_equal "acme.com", Tenant.email_domain(" owner@acme.com ".strip)
+  end
+
+  test "email_domain returns nil for values with no domain part" do
+    assert_nil Tenant.email_domain(nil)
+    assert_nil Tenant.email_domain("")
+    assert_nil Tenant.email_domain("not-an-email")
+    assert_nil Tenant.email_domain("trailing@")
+  end
+
+  test "reply_ignored_domains includes the account owners' domains and the platform domain" do
+    tenant = Tenant.create!(name: "Restoration Co")
+    User.create!(email: "owner@restoration.co", password: "Password1", tenant: tenant)
+
+    domains = tenant.reply_ignored_domains
+    assert_includes domains, "restoration.co"
+    assert_includes domains, Tenant::SERVICEMARK_DOMAIN
+  end
+
+  test "reply_ignored_domains excludes the domains of location-scoped users" do
+    tenant = Tenant.create!(name: "Restoration Co")
+    location = tenant.locations.create!(
+      display_name: "Main", address_line_1: "1 Main", city: "Dallas",
+      state: "TX", postal_code: "75001", phone_number: "(214) 555-0101", is_active: true
+    )
+    User.create!(email: "owner@restoration.co", password: "Password1", tenant: tenant)
+    User.create!(email: "tech@gmail.com", password: "Password1", tenant: tenant, location: location)
+
+    assert_not_includes tenant.reply_ignored_domains, "gmail.com"
+  end
+
+  test "reply_ignored_domains de-dupes owners that share a domain" do
+    tenant = Tenant.create!(name: "Restoration Co")
+    User.create!(email: "owner-a@restoration.co", password: "Password1", tenant: tenant)
+    User.create!(email: "owner-b@restoration.co", password: "Password1", tenant: tenant)
+
+    assert_equal 1, tenant.reply_ignored_domains.count("restoration.co")
+  end
+
+  test "reply_ignored_sender? is true for the tenant's own domain and the platform domain" do
+    tenant = Tenant.create!(name: "Restoration Co")
+    User.create!(email: "owner@restoration.co", password: "Password1", tenant: tenant)
+
+    assert tenant.reply_ignored_sender?("someone-else@restoration.co")
+    assert tenant.reply_ignored_sender?("staff@servicemark.ai")
+    assert tenant.reply_ignored_sender?("Owner@Restoration.CO"), "matching is case-insensitive"
+  end
+
+  test "reply_ignored_sender? is false for an outside customer and blank input" do
+    tenant = Tenant.create!(name: "Restoration Co")
+    User.create!(email: "owner@restoration.co", password: "Password1", tenant: tenant)
+
+    assert_not tenant.reply_ignored_sender?("customer@elsewhere.com")
+    assert_not tenant.reply_ignored_sender?(nil)
+    assert_not tenant.reply_ignored_sender?("")
+  end
 end


### PR DESCRIPTION
Fixes #227 

## Summary

Two related changes to the customer-replied campaign-stop behavior.

### 1. Scope the customer-replied trigger to genuine customer replies

A campaign should stop when the **customer** replies — not when the
thread is forwarded internally, CC'd to a teammate, or touched by
ServiceMark AI staff.

- `Tenant#reply_ignored_domains` / `#reply_ignored_sender?` resolve the
  domains whose replies are ignored: the account's own domains (derived
  from the email addresses of tenant owners — users with no location)
  plus `servicemark.ai`.
- `GmailReplyPollJob` skips inbound messages from those domains and
  keeps scanning, so a real customer reply further down the thread
  still trips the stop. Bounce detection is unaffected.
- The **/users** page lists the ignored reply domains at the bottom.

### 2. Resume a campaign stopped on a customer reply

"Customer waiting" is a hand-off, not a terminal state.

- `JobProposalsController#resume` now also accepts a campaign stopped on
  a customer reply, not just a manually paused one.
- Before resuming, the recorded reply is folded into each step's thread
  snapshot so the reply poller treats it as baseline — otherwise the
  next tick would re-detect the same reply and re-stop the campaign.
- The proposal show page gains a **Resume campaign** secondary CTA when
  the campaign stopped on a reply (the primary CTA stays Open in Gmail).
- User guide §4d documents the resume path.

## Testing

`docker-compose exec web bundle exec rails db:test:prepare test test:system` — 873 + 8 tests, 0 failures. New coverage for the domain helpers, the poller's ignore-domain path, the resume action (including snapshot re-baselining), and the new UI sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)