### PR TITLE
text the proposal owner when a customer replies (fixes #231)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,18 @@ SENTRY_DSN=
 # redirected here instead of going to the real customer address.
 # Devise mailers (password reset, etc.) are unaffected.
 TEST_TO_EMAIL=
+
+# Twilio (read by app/services/sms_senders/twilio.rb). When all three
+# are set, the SmsSender abstraction picks Twilio as the active provider
+# and the proposal owner gets a text when their customer replies.
+# Unset = SMS quietly off (no other behavior changes).
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
+
+# Outbound SMS safety gate (read by app/services/sms_sender.rb).
+# Mirrors TEST_TO_EMAIL: when set in any environment, every outbound
+# SMS is redirected to this number instead of the real recipient.
+# Useful in dev for confirming real Twilio sends without texting a
+# real teammate.
+TEST_TO_PHONE=

--- a/app/controllers/job_proposals_controller.rb
+++ b/app/controllers/job_proposals_controller.rb
@@ -3,7 +3,7 @@ class JobProposalsController < ApplicationController
   ALLOWED_DIRS  = %w[asc desc].freeze
 
   EDITABLE_PARAMS = %i[
-    customer_title customer_first_name customer_last_name customer_email
+    customer_title customer_first_name customer_last_name customer_email customer_phone
     customer_house_number customer_street customer_city customer_state customer_zip
     internal_reference dash_job_number loss_notes loss_reason_id
     owner_id job_type_id scenario_id proposal_value
@@ -478,6 +478,7 @@ class JobProposalsController < ApplicationController
     scope.where(<<~SQL.squish, p: pattern)
       customer_first_name   ILIKE :p OR
       customer_last_name    ILIKE :p OR
+      customer_phone        ILIKE :p OR
       customer_house_number ILIKE :p OR
       customer_street       ILIKE :p OR
       customer_city         ILIKE :p OR

--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -1,0 +1,15 @@
+class ShortLinksController < ApplicationController
+  # Public redirect — recipients of the SMS will hit this endpoint
+  # straight from their phone before they're signed in. Skip the
+  # app-wide authentication guard for this one action.
+  skip_before_action :authenticate_user!, only: :show
+
+  def show
+    link = ShortLink.find_by(code: params[:id])
+    if link
+      redirect_to link.target_url, allow_other_host: true, status: :found
+    else
+      render plain: "Link not found", status: :not_found
+    end
+  end
+end

--- a/app/jobs/proposal_reply_notification_job.rb
+++ b/app/jobs/proposal_reply_notification_job.rb
@@ -1,0 +1,76 @@
+class ProposalReplyNotificationJob < ApplicationJob
+  queue_as :default
+
+  # Texts the JobProposal owner that the customer replied to one of the
+  # campaign emails. Composed from the proposal's customer fields and a
+  # short link that redirects the owner into the Gmail thread on their
+  # phone. No-ops (with a log line) when:
+  #
+  #   - the step instance vanished between flag! and the job firing
+  #   - the host isn't a JobProposal (other host types don't carry the
+  #     customer fields the SMS body needs)
+  #   - the owner has no phone_number on file
+  #   - SmsSender has no provider wired (TEST_TO_PHONE etc. unset)
+  #
+  # The SMS provider abstraction (SmsSender) handles dev-mode redirection
+  # via TEST_TO_PHONE and test-mode capture via SmsSender.deliveries.
+  def perform(step_instance_id)
+    step_instance = CampaignStepInstance.find_by(id: step_instance_id)
+    return log_skip("step instance #{step_instance_id} no longer exists") if step_instance.nil?
+
+    instance = step_instance.campaign_instance
+    proposal = instance&.host
+    return log_skip("host is not a JobProposal (instance #{instance&.id})") unless proposal.is_a?(JobProposal)
+
+    owner = proposal.owner
+    return log_skip("proposal #{proposal.id} owner has no phone_number") if owner&.phone_number.blank?
+
+    body = compose_body(proposal)
+    SmsSender.deliver(to: owner.phone_number, body: body)
+  end
+
+  private
+
+  def compose_body(proposal)
+    lines = []
+    lines << "Customer reply: #{customer_name(proposal)}"
+    lines << proposal.short_address if proposal.short_address.present?
+    lines << "Phone: #{proposal.customer_phone}" if proposal.customer_phone.present?
+    lines << "DASH: #{proposal.dash_job_number}" if proposal.dash_job_number.present?
+    if (open_url = open_in_gmail_url(proposal))
+      lines << "Open: #{open_url}"
+    end
+    lines.join("\n")
+  end
+
+  def customer_name(proposal)
+    [proposal.customer_first_name, proposal.customer_last_name].compact_blank.join(" ").presence ||
+      proposal.customer_email.presence ||
+      "(no name)"
+  end
+
+  # Wraps the Gmail thread URL in a ShortLink and returns the public
+  # short URL the SMS recipient will tap. Returns nil when there's no
+  # thread yet (proposal never sent an email) — caller drops the line.
+  def open_in_gmail_url(proposal)
+    thread_id = proposal.gmail_thread_id
+    return nil if thread_id.blank?
+
+    gmail_url = "https://mail.google.com/mail/u/0/#all/#{thread_id}"
+    link = ShortLink.for(gmail_url)
+    Rails.application.routes.url_helpers.short_link_url(link.code, host: app_host, protocol: app_protocol)
+  end
+
+  def app_host
+    ActionMailer::Base.default_url_options[:host] || "localhost"
+  end
+
+  def app_protocol
+    ActionMailer::Base.default_url_options[:protocol] || (Rails.env.production? ? "https" : "http")
+  end
+
+  def log_skip(reason)
+    Rails.logger.info "[ProposalReplyNotificationJob] skip: #{reason}"
+    nil
+  end
+end

--- a/app/models/short_link.rb
+++ b/app/models/short_link.rb
@@ -1,0 +1,30 @@
+class ShortLink < ApplicationRecord
+  validates :code, presence: true, uniqueness: true
+  validates :target_url, presence: true
+
+  before_validation :assign_code, on: :create
+
+  # Returns an existing row for the same target_url when one is already
+  # stored, otherwise creates a fresh one. SMS bodies stay short and the
+  # short_links table doesn't bloat with one row per resend.
+  def self.for(target_url)
+    return nil if target_url.blank?
+    find_by(target_url: target_url) || create!(target_url: target_url)
+  end
+
+  def short_path
+    "/r/#{code}"
+  end
+
+  private
+
+  def assign_code
+    return if code.present?
+    loop do
+      candidate = SecureRandom.urlsafe_base64(6).tr("_-", "ab")
+      next if self.class.exists?(code: candidate)
+      self.code = candidate
+      break
+    end
+  end
+end

--- a/app/services/customer_reply_handler.rb
+++ b/app/services/customer_reply_handler.rb
@@ -34,5 +34,10 @@ class CustomerReplyHandler
       end
       host.update!(status_overlay: "customer_waiting") if host.is_a?(JobProposal)
     end
+
+    # Enqueue *after* the transaction commits so the SMS job doesn't
+    # observe stale state if the surrounding write rolls back. The job
+    # itself no-ops when no SMS provider is configured.
+    ProposalReplyNotificationJob.perform_later(@step_instance.id) if host.is_a?(JobProposal)
   end
 end

--- a/app/services/integration_status.rb
+++ b/app/services/integration_status.rb
@@ -31,7 +31,14 @@ class IntegrationStatus
       app_host,
       sentry,
       test_to_email
-    ]
+    ] + sms_provider_rows
+  end
+
+  # One row per known SMS provider (currently only Twilio). The provider
+  # itself owns its label, env-var list, and recommendation text — see
+  # SmsSender for the dispatch contract.
+  def sms_provider_rows
+    SmsSender.provider_status_rows
   end
 
   private

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -1,0 +1,96 @@
+require "net/http"
+require "uri"
+require "json"
+
+# Sends outbound SMS through whichever provider is wired by env. The
+# first provider in PROVIDERS whose required env vars are all present
+# wins — that's the "use the existence of an env variable as signal"
+# rule from issue #231. Add a new provider by appending it to PROVIDERS
+# and giving it the same class-level interface (.label, .configured?,
+# .partially_configured?, .missing_env_vars, .status_row, .env_vars)
+# plus an instance #send_sms(to:, body:).
+#
+# In Rails.env.test no HTTP fires — sends are recorded on `deliveries`
+# so tests can assert what would have gone out, matching GmailSender.
+#
+# In any environment, when TEST_TO_PHONE is set, all SMS is redirected
+# to that number instead of going to the real recipient. Mirrors the
+# TEST_TO_EMAIL gate used by the campaign sweep — lets a developer
+# point real Twilio sends at a test phone without touching code.
+class SmsSender
+  Result = Struct.new(:provider, :sid, :to, :body, :status, keyword_init: true)
+
+  PROVIDERS = %w[SmsSenders::Twilio].freeze
+
+  class << self
+    def deliveries
+      @deliveries ||= []
+    end
+
+    def reset_deliveries!
+      @deliveries = []
+    end
+
+    # First provider class whose env vars are all present, or nil when
+    # nothing is configured.
+    def active_provider
+      provider_classes.find(&:configured?)
+    end
+
+    def configured?
+      active_provider.present?
+    end
+
+    def provider_name
+      active_provider&.label
+    end
+
+    # Send an SMS. Returns a Result on success, nil when nothing was
+    # sent (no provider configured, blank recipient, or provider failure).
+    def deliver(to:, body:)
+      provider = active_provider
+      if provider.nil?
+        Rails.logger.warn "[SmsSender] no SMS provider configured; dropping send to #{to.inspect}"
+        return nil
+      end
+
+      destination = effective_recipient(to)
+      if destination.blank?
+        Rails.logger.warn "[SmsSender] no destination phone (override or real) — dropping send"
+        return nil
+      end
+
+      if Rails.env.test?
+        stub = Result.new(
+          provider: provider.label,
+          sid:      "test-#{SecureRandom.hex(4)}",
+          to:       destination,
+          body:     body,
+          status:   "queued"
+        )
+        deliveries << stub
+        return stub
+      end
+
+      provider.new.send_sms(to: destination, body: body)
+    end
+
+    # Snapshot of every known provider for the Integrations admin page.
+    # Each entry is whatever the provider's .status_row returns — an
+    # IntegrationStatus::Status with the provider's name baked in.
+    def provider_status_rows
+      provider_classes.map(&:status_row)
+    end
+
+    def provider_classes
+      PROVIDERS.map(&:constantize)
+    end
+
+    private
+
+    def effective_recipient(to)
+      override = ENV["TEST_TO_PHONE"].to_s.strip
+      override.present? ? override : to.to_s.strip
+    end
+  end
+end

--- a/app/services/sms_senders/twilio.rb
+++ b/app/services/sms_senders/twilio.rb
@@ -1,0 +1,89 @@
+require "net/http"
+require "uri"
+require "json"
+
+# Twilio Programmable Messaging implementation of the SmsSender
+# provider interface. Selected automatically by SmsSender when all
+# three env vars are set — see SmsSender for the dispatch contract
+# and the test-mode / TEST_TO_PHONE override behavior.
+module SmsSenders
+  class Twilio
+    ENV_VARS = %w[TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER].freeze
+    API_HOST = "api.twilio.com".freeze
+
+    def self.label
+      "Twilio"
+    end
+
+    def self.configured?
+      ENV_VARS.all? { |k| ENV[k].present? }
+    end
+
+    def self.partially_configured?
+      ENV_VARS.any? { |k| ENV[k].present? } && !configured?
+    end
+
+    def self.missing_env_vars
+      ENV_VARS.reject { |k| ENV[k].present? }
+    end
+
+    # Row consumed by IntegrationStatus → admin Integrations page.
+    def self.status_row
+      if configured?
+        IntegrationStatus::Status.new(
+          name:           "Text messaging (Twilio)",
+          state:          :ok,
+          details:        "Sending from #{ENV['TWILIO_FROM_NUMBER']} as account #{redacted_account_sid}.",
+          recommendation: nil
+        )
+      elsif partially_configured?
+        IntegrationStatus::Status.new(
+          name:           "Text messaging (Twilio)",
+          state:          :warn,
+          details:        "Partial Twilio config — missing: #{missing_env_vars.join(', ')}.",
+          recommendation: "Finish setting the remaining Twilio env vars and redeploy."
+        )
+      else
+        IntegrationStatus::Status.new(
+          name:           "Text messaging (Twilio)",
+          state:          :missing,
+          details:        "Not configured. Reply notifications by SMS will not send.",
+          recommendation: "Set #{ENV_VARS.join(', ')} and redeploy. See production setup §0.5a."
+        )
+      end
+    end
+
+    def self.redacted_account_sid
+      sid = ENV["TWILIO_ACCOUNT_SID"].to_s
+      sid.length > 8 ? "#{sid[0, 4]}…#{sid[-4, 4]}" : sid
+    end
+
+    def send_sms(to:, body:)
+      account_sid = ENV.fetch("TWILIO_ACCOUNT_SID")
+      auth_token  = ENV.fetch("TWILIO_AUTH_TOKEN")
+      from        = ENV.fetch("TWILIO_FROM_NUMBER")
+
+      uri = URI("https://#{API_HOST}/2010-04-01/Accounts/#{account_sid}/Messages.json")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = Net::HTTP::Post.new(uri)
+      req.basic_auth(account_sid, auth_token)
+      req.set_form_data(From: from, To: to, Body: body)
+      response = http.request(req)
+
+      if response.code.to_i.between?(200, 299)
+        data = JSON.parse(response.body) rescue {}
+        SmsSender::Result.new(
+          provider: self.class.label,
+          sid:      data["sid"],
+          to:       to,
+          body:     body,
+          status:   data["status"] || "queued"
+        )
+      else
+        Rails.logger.warn "[SmsSenders::Twilio] send failed (#{response.code}): #{response.body}"
+        nil
+      end
+    end
+  end
+end

--- a/app/views/job_proposals/edit.html.erb
+++ b/app/views/job_proposals/edit.html.erb
@@ -53,10 +53,15 @@
           <%= f.label :customer_last_name, "Last name", class: "form-label" %>
           <%= f.text_field :customer_last_name, class: "form-control", disabled: @campaign_in_flight %>
         </div>
-        <div class="col-md-12">
+        <div class="col-md-7">
           <%= f.label :customer_email, class: "form-label" do %>Email<%= required_marker %><% end %>
           <%= f.email_field :customer_email, class: "form-control", required: true, disabled: @campaign_in_flight %>
           <%= readiness_warning_for(@job_proposal, :customer_email) %>
+        </div>
+        <div class="col-md-5">
+          <%= f.label :customer_phone, "Phone", class: "form-label" %>
+          <%= f.telephone_field :customer_phone, class: "form-control", disabled: @campaign_in_flight, placeholder: "+1 555-123-4567" %>
+          <div class="form-text">Shown in the text message that's sent to the proposal owner when the customer replies.</div>
         </div>
         <div class="col-md-3">
           <%= f.label :customer_house_number, class: "form-label" do %>House #<%= required_marker %><% end %>

--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -82,6 +82,15 @@
         <% end %>
       </dd>
 
+      <dt class="col-sm-3">Phone</dt>
+      <dd class="col-sm-9">
+        <% if @job_proposal.customer_phone.present? %>
+          <%= @job_proposal.customer_phone %>
+        <% else %>
+          <span class="text-muted">—</span>
+        <% end %>
+      </dd>
+
       <dt class="col-sm-3">Address</dt>
       <dd class="col-sm-9">
         <% if @job_proposal.short_address %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
   authenticate :user, ->(u) { u.is_admin } do
     mount Sidekiq::Web => "/sidekiq"
   end
+  # Public short-link redirect. Recipients of outbound SMS land here
+  # before they're signed in, so the action skips Devise auth.
+  get "/r/:id", to: "short_links#show", as: :short_link
+
   resources :invitations, only: [:show, :create, :destroy]
   resources :users, only: [:index, :edit, :update]
   get "profile" => "profiles#show", as: :profile

--- a/db/migrate/20260524225836_add_customer_phone_to_job_proposals.rb
+++ b/db/migrate/20260524225836_add_customer_phone_to_job_proposals.rb
@@ -1,0 +1,5 @@
+class AddCustomerPhoneToJobProposals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :job_proposals, :customer_phone, :string
+  end
+end

--- a/db/migrate/20260524225837_create_short_links.rb
+++ b/db/migrate/20260524225837_create_short_links.rb
@@ -1,0 +1,10 @@
+class CreateShortLinks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :short_links do |t|
+      t.string :code, null: false
+      t.text :target_url, null: false
+      t.timestamps
+    end
+    add_index :short_links, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_23_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_24_225837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -232,6 +232,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_180000) do
     t.string "customer_first_name"
     t.string "customer_house_number"
     t.string "customer_last_name"
+    t.string "customer_phone"
     t.string "customer_state"
     t.string "customer_street"
     t.string "customer_title"
@@ -370,6 +371,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_180000) do
     t.index ["campaign_id"], name: "index_scenarios_on_campaign_id"
     t.index ["job_type_id", "code"], name: "index_scenarios_on_job_type_id_and_code", unique: true
     t.index ["job_type_id"], name: "index_scenarios_on_job_type_id"
+  end
+
+  create_table "short_links", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.text "target_url", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_short_links_on_code", unique: true
   end
 
   create_table "tenant_job_types", force: :cascade do |t|

--- a/docs/user-guide/00-production-setup.md
+++ b/docs/user-guide/00-production-setup.md
@@ -153,6 +153,29 @@ config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "localh
 
 If `APP_HOST` is unset, the app boots with a `localhost` fallback so a deploy isn't blocked, but the resulting mailer links would be broken. The in-app missing-env banner surfaces `APP_HOST` as missing on every admin screen in non-development environments, so a fresh deploy gets flagged loudly before any mail goes out. Set `APP_HOST` to your Heroku domain (or your custom domain from §0.6) — it's already in the §0.4 `heroku config:set` block. Staging and production each carry their own value, no code edits required. Development doesn't need `APP_HOST` at all; the dev mailer host comes from Rails' default URL options, not this var.
 
+## 0.5a (Optional) Twilio text-message notifications
+
+When a customer replies to a campaign email, the proposal owner gets a text message with the customer's name, address, phone, DASH number, and a tap-through link into the Gmail conversation. The send is gated by env vars — if these are unset, the feature is quietly off and nothing else in the app changes.
+
+Set up a Twilio account, pick a from-number, and set:
+
+```bash
+heroku config:set \
+  TWILIO_ACCOUNT_SID=AC… \
+  TWILIO_AUTH_TOKEN=… \
+  TWILIO_FROM_NUMBER=+15555550123 \
+  -a <app-name>
+```
+
+Notes:
+
+- The app uses a provider-agnostic `SmsSender` that picks the first configured provider by env-var presence. Twilio is the only provider today; the abstraction is in place so a swap won't require touching the reply path.
+- `TEST_TO_PHONE` (optional) is the SMS counterpart of `TEST_TO_EMAIL`. When set in any environment, every outbound SMS is redirected to that number instead of the real recipient — use this in staging or for a smoke test before pointing real Twilio sends at teammates' phones.
+- For SMS to reach a given user, that user's profile must have a `phone number` filled in. The job no-ops silently for owners without one.
+- The deep-link to Gmail in the SMS body goes through the app's own short-link redirect (`/r/<code>`), so the message stays well under the 160-character SMS limit.
+
+The Integrations admin page shows a **Text messaging (Twilio)** row with three states: **OK** when all three vars are set; **Warning** when the config is partial; **Missing** when none are set.
+
 ## 0.6 (Optional) Custom domain and SSL
 
 ```bash

--- a/docs/user-guide/04-campaign-maintenance.md
+++ b/docs/user-guide/04-campaign-maintenance.md
@@ -63,6 +63,8 @@ The job's detail page shows a **Customer** card, a **Job** card with status and 
 
 When a customer replies to a campaign email, the system stops sending — no more follow-ups go out on that thread. The job is flagged as **waiting on the customer** so you can spot it on the board.
 
+You'll also get a **text message on your phone**, as long as your tenant has SMS turned on and your profile has a phone number on file. The text identifies the customer (name, address, phone, DASH number) and includes a short link you can tap to open the Gmail conversation directly. If you don't want the texts, clear the phone number on **Profile → Edit**.
+
 What you'll see on the **Jobs** board:
 
 - The card's action button reads **Open in Gmail** — click it to jump straight to the conversation in a new tab and reply from your usual inbox.

--- a/test/controllers/short_links_controller_test.rb
+++ b/test/controllers/short_links_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class ShortLinksControllerTest < ActionDispatch::IntegrationTest
+  test "GET /r/:code redirects to the stored target_url" do
+    link = ShortLink.create!(target_url: "https://mail.google.com/mail/u/0/#all/thread-123")
+    get "/r/#{link.code}"
+    assert_response :found
+    assert_redirected_to "https://mail.google.com/mail/u/0/#all/thread-123"
+  end
+
+  test "GET /r/:code with an unknown code returns 404" do
+    get "/r/does-not-exist"
+    assert_response :not_found
+  end
+
+  test "the redirect endpoint is public — no sign-in required" do
+    # No sign_in / no devise session: the SMS recipient hits this on
+    # their phone before they've authenticated.
+    link = ShortLink.create!(target_url: "https://example.com/")
+    get "/r/#{link.code}"
+    assert_response :found
+  end
+end

--- a/test/jobs/proposal_reply_notification_job_test.rb
+++ b/test/jobs/proposal_reply_notification_job_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class ProposalReplyNotificationJobTest < ActiveJob::TestCase
+  setup do
+    @prior_env = %w[TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER]
+                 .to_h { |k| [k, ENV[k]] }
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1234567890"
+    ENV["TWILIO_AUTH_TOKEN"]  = "tok"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+
+    @owner    = users(:one)
+    @owner.update!(phone_number: "+15555550100")
+    @proposal = job_proposals(:in_users_org)
+    @proposal.update!(
+      owner: @owner,
+      status: :approved,
+      pipeline_stage: :in_campaign,
+      customer_email: "alice@example.com",
+      customer_first_name: "Alice",
+      customer_last_name: "Smith",
+      customer_phone: "+15551234567",
+      customer_house_number: "123",
+      customer_street: "Main St",
+      dash_job_number: "12345"
+    )
+    @campaign      = campaigns(:approved_campaign)
+    @step          = campaign_steps(:approved_step_one)
+    @instance      = CampaignInstance.create!(host: @proposal, campaign: @campaign, status: :active)
+    @step_instance = CampaignStepInstance.create!(
+      campaign_instance: @instance,
+      campaign_step: @step,
+      planned_delivery_at: 1.hour.ago,
+      email_delivery_status: :sent,
+      gmail_thread_id: "thread-abc",
+      final_subject: "Hi",
+      final_body: "Body"
+    )
+  end
+
+  teardown do
+    @prior_env.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+
+  test "sends an SMS to the owner's phone with the customer's name, address, phone, and DASH" do
+    perform_now
+    delivery = SmsSender.deliveries.last
+    assert_equal "+15555550100", delivery.to
+    assert_match "Alice Smith", delivery.body
+    assert_match "123 Main St", delivery.body
+    assert_match "+15551234567", delivery.body
+    assert_match "DASH: 12345", delivery.body
+  end
+
+  test "the SMS body includes a short link that resolves to the gmail thread url" do
+    perform_now
+    delivery = SmsSender.deliveries.last
+    url_match = delivery.body.match(%r{(https?://\S+/r/[A-Za-z0-9]+)})
+    assert url_match, "expected a /r/<code> short link in the body, got: #{delivery.body}"
+
+    code = url_match[1].split("/r/").last
+    link = ShortLink.find_by(code: code)
+    assert link, "no ShortLink row written for code #{code.inspect}"
+    assert_equal "https://mail.google.com/mail/u/0/#all/thread-abc", link.target_url
+  end
+
+  test "skips silently when the owner has no phone number on file" do
+    @owner.update!(phone_number: nil)
+    perform_now
+    assert_empty SmsSender.deliveries
+  end
+
+  test "skips silently when no SMS provider is configured" do
+    %w[TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER].each { |k| ENV.delete(k) }
+    perform_now
+    assert_empty SmsSender.deliveries
+  end
+
+  test "skips silently when the step instance no longer exists" do
+    id = @step_instance.id
+    @step_instance.destroy!
+    ProposalReplyNotificationJob.new.perform(id)
+    assert_empty SmsSender.deliveries
+  end
+
+  private
+
+  def perform_now
+    ProposalReplyNotificationJob.new.perform(@step_instance.id)
+  end
+end

--- a/test/models/short_link_test.rb
+++ b/test/models/short_link_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class ShortLinkTest < ActiveSupport::TestCase
+  test "create assigns a unique url-safe code" do
+    a = ShortLink.create!(target_url: "https://example.com/a")
+    b = ShortLink.create!(target_url: "https://example.com/b")
+    assert_match(/\A[A-Za-z0-9]+\z/, a.code)
+    refute_equal a.code, b.code
+  end
+
+  test "code is required to be unique at the DB level" do
+    ShortLink.create!(target_url: "https://example.com/a")
+    dup = ShortLink.new(code: ShortLink.first.code, target_url: "https://example.com/b")
+    refute dup.valid?
+  end
+
+  test ".for reuses an existing row when one exists for the same target" do
+    first  = ShortLink.for("https://mail.google.com/mail/u/0/#all/abc")
+    second = ShortLink.for("https://mail.google.com/mail/u/0/#all/abc")
+    assert_equal first.id, second.id
+  end
+
+  test ".for creates a new row for a new target" do
+    a = ShortLink.for("https://mail.google.com/mail/u/0/#all/abc")
+    b = ShortLink.for("https://mail.google.com/mail/u/0/#all/xyz")
+    refute_equal a.id, b.id
+  end
+
+  test ".for returns nil for blank input" do
+    assert_nil ShortLink.for(nil)
+    assert_nil ShortLink.for("")
+  end
+
+  test "short_path is /r/<code>" do
+    link = ShortLink.create!(target_url: "https://example.com/")
+    assert_equal "/r/#{link.code}", link.short_path
+  end
+end

--- a/test/services/customer_reply_handler_test.rb
+++ b/test/services/customer_reply_handler_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class CustomerReplyHandlerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
   setup do
     @proposal = job_proposals(:in_users_org)
     @proposal.update!(
@@ -62,5 +63,11 @@ class CustomerReplyHandlerTest < ActiveSupport::TestCase
     # reply landing, and the whole point of issue #240's plumbing.
     CustomerReplyHandler.flag!(@step_instance, @reply_payload)
     assert_includes JobProposal.needs_attention, @proposal.reload
+  end
+
+  test "enqueues a ProposalReplyNotificationJob so the owner gets a text" do
+    assert_enqueued_with(job: ProposalReplyNotificationJob, args: [@step_instance.id]) do
+      CustomerReplyHandler.flag!(@step_instance, @reply_payload)
+    end
   end
 end

--- a/test/services/integration_status_test.rb
+++ b/test/services/integration_status_test.rb
@@ -6,6 +6,7 @@ class IntegrationStatusTest < ActiveSupport::TestCase
     APP_HOST TEST_TO_EMAIL REDIS_URL
     GCS_PROJECT GCS_BUCKET GCS_CREDENTIALS
     AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_BUCKET
+    TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER
   ].freeze
 
   setup do
@@ -20,11 +21,37 @@ class IntegrationStatusTest < ActiveSupport::TestCase
 
   test "all returns one Status per integration" do
     statuses = IntegrationStatus.all
-    assert_equal 8, statuses.size
+    assert_equal 9, statuses.size
     statuses.each do |s|
       assert_kind_of IntegrationStatus::Status, s
       assert_includes %i[ok warn missing], s.state
     end
+  end
+
+  # --- SMS (Twilio) -------------------------------------------------------
+
+  test "twilio SMS is :missing when no env vars are set" do
+    s = find_status("Text messaging (Twilio)")
+    assert_equal :missing, s.state
+    assert_match "TWILIO_ACCOUNT_SID", s.recommendation
+  end
+
+  test "twilio SMS is :warn when partially configured" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC123"
+    s = find_status("Text messaging (Twilio)")
+    assert_equal :warn, s.state
+    assert_match "TWILIO_AUTH_TOKEN", s.details
+    assert_match "TWILIO_FROM_NUMBER", s.details
+  end
+
+  test "twilio SMS is :ok when all three env vars are set" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1234567890"
+    ENV["TWILIO_AUTH_TOKEN"]  = "secret"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+    s = find_status("Text messaging (Twilio)")
+    assert_equal :ok, s.state
+    assert_match "+15555550123", s.details
+    refute_match "secret", s.details
   end
 
   # --- Application mailbox ------------------------------------------------

--- a/test/services/sms_sender_test.rb
+++ b/test/services/sms_sender_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class SmsSenderTest < ActiveSupport::TestCase
+  ENV_KEYS = %w[TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER TEST_TO_PHONE].freeze
+
+  setup do
+    @prior_env = ENV_KEYS.to_h { |k| [k, ENV[k]] }
+    ENV_KEYS.each { |k| ENV.delete(k) }
+  end
+
+  teardown do
+    ENV_KEYS.each { |k| @prior_env[k].nil? ? ENV.delete(k) : ENV[k] = @prior_env[k] }
+  end
+
+  test "configured? is false when no provider env vars are set" do
+    refute_predicate SmsSender, :configured?
+    assert_nil SmsSender.provider_name
+    assert_nil SmsSender.active_provider
+  end
+
+  test "twilio becomes the active provider once all three env vars are set" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1"
+    ENV["TWILIO_AUTH_TOKEN"]  = "tok"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+    assert_predicate SmsSender, :configured?
+    assert_equal "Twilio", SmsSender.provider_name
+    assert_equal SmsSenders::Twilio, SmsSender.active_provider
+  end
+
+  test "deliver returns nil and records nothing when no provider is configured" do
+    assert_nil SmsSender.deliver(to: "+15555550100", body: "hi")
+    assert_empty SmsSender.deliveries
+  end
+
+  test "deliver in test env captures the send on deliveries without HTTP" do
+    configure_twilio_env
+    result = SmsSender.deliver(to: "+15555550100", body: "hi from test")
+
+    assert_equal "Twilio", result.provider
+    assert_equal "+15555550100", result.to
+    assert_equal "hi from test", result.body
+    assert_match(/^test-/, result.sid)
+    assert_equal 1, SmsSender.deliveries.size
+    assert_equal result, SmsSender.deliveries.last
+  end
+
+  test "TEST_TO_PHONE redirects all outbound SMS to the override number" do
+    configure_twilio_env
+    ENV["TEST_TO_PHONE"] = "+15555559999"
+    result = SmsSender.deliver(to: "+15555550100", body: "hi")
+    assert_equal "+15555559999", result.to
+  end
+
+  test "deliver drops when destination is blank after override resolution" do
+    configure_twilio_env
+    assert_nil SmsSender.deliver(to: " ", body: "hi")
+    assert_empty SmsSender.deliveries
+  end
+
+  test "provider_status_rows returns one Status per known provider" do
+    rows = SmsSender.provider_status_rows
+    assert_equal 1, rows.size
+    assert_equal "Text messaging (Twilio)", rows.first.name
+  end
+
+  private
+
+  def configure_twilio_env
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1234567890"
+    ENV["TWILIO_AUTH_TOKEN"]  = "tok"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+  end
+end

--- a/test/services/sms_senders/twilio_test.rb
+++ b/test/services/sms_senders/twilio_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class SmsSenders::TwilioTest < ActiveSupport::TestCase
+  ENV_KEYS = %w[TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER].freeze
+
+  setup do
+    @prior_env = ENV_KEYS.to_h { |k| [k, ENV[k]] }
+    ENV_KEYS.each { |k| ENV.delete(k) }
+  end
+
+  teardown do
+    ENV_KEYS.each { |k| @prior_env[k].nil? ? ENV.delete(k) : ENV[k] = @prior_env[k] }
+  end
+
+  test "configured? requires all three env vars" do
+    refute_predicate SmsSenders::Twilio, :configured?
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1"
+    ENV["TWILIO_AUTH_TOKEN"]  = "tok"
+    refute_predicate SmsSenders::Twilio, :configured?
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+    assert_predicate SmsSenders::Twilio, :configured?
+  end
+
+  test "partially_configured? flips on once any env var is set, off once all are" do
+    refute_predicate SmsSenders::Twilio, :partially_configured?
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1"
+    assert_predicate SmsSenders::Twilio, :partially_configured?
+    ENV["TWILIO_AUTH_TOKEN"]  = "tok"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+    refute_predicate SmsSenders::Twilio, :partially_configured?
+  end
+
+  test "missing_env_vars lists only the absent keys" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1"
+    assert_equal %w[TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER], SmsSenders::Twilio.missing_env_vars
+  end
+
+  test "status_row reports :missing with a recommendation when nothing is set" do
+    row = SmsSenders::Twilio.status_row
+    assert_equal :missing, row.state
+    assert_match "TWILIO_ACCOUNT_SID", row.recommendation
+  end
+
+  test "status_row reports :warn with the missing keys when partially set" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1"
+    row = SmsSenders::Twilio.status_row
+    assert_equal :warn, row.state
+    assert_match "TWILIO_AUTH_TOKEN", row.details
+  end
+
+  test "status_row reports :ok with redacted SID and visible from-number when fully set" do
+    ENV["TWILIO_ACCOUNT_SID"] = "AC1234567890abcd"
+    ENV["TWILIO_AUTH_TOKEN"]  = "supersecret"
+    ENV["TWILIO_FROM_NUMBER"] = "+15555550123"
+    row = SmsSenders::Twilio.status_row
+    assert_equal :ok, row.state
+    assert_match "+15555550123", row.details
+    refute_match "supersecret", row.details
+    refute_match "1234567890abcd", row.details
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,10 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    setup { GmailSender.reset_deliveries! }
+    setup do
+      GmailSender.reset_deliveries!
+      SmsSender.reset_deliveries!
+    end
 
     # Add more helper methods to be used by all tests here...
   end


### PR DESCRIPTION
## Summary
- New `SmsSender` provider abstraction picks the first provider whose env vars are all present; `SmsSenders::Twilio` is the only one wired today. The reply handler enqueues `ProposalReplyNotificationJob`, which composes the message (name / address / customer phone / DASH number / tap-through short link) and sends it to the proposal owner's phone.
- Adds `customer_phone` on JobProposal (form + show + search), a `short_links` table with a public `/r/:code` redirect so the Gmail deep link stays under the SMS limit, and a **Text messaging (Twilio)** row on the admin Integrations page (OK / Warning / Missing).
- `TEST_TO_PHONE` is the SMS counterpart of `TEST_TO_EMAIL` — redirect every send to one number for staging or smoke-tests. In `Rails.env.test` no HTTP fires; sends land on `SmsSender.deliveries`.

## Test plan
- [x] `rails test` (965 runs, 3981 assertions, 0 failures)
- [x] `rails test:system` (8 runs, 0 failures)
- [x] `cucumber` (22 scenarios, 0 failures)
- [ ] Smoke-test in staging with real Twilio creds + `TEST_TO_PHONE` set to a personal number, simulate a reply, verify text arrives and the short link opens the Gmail thread on mobile.
- [ ] Confirm **Admin → Integrations** shows the new Twilio row in all three states (set / partial / unset env vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)