### PR TITLE
Issue #255: Build Mark Won confirmation modal (JD-005)

### DIFF
--- a/app/views/job_proposals/show.html.erb
+++ b/app/views/job_proposals/show.html.erb
@@ -20,10 +20,10 @@
           form: { class: "d-inline" },
           title: "Undo an accidental Mark Won / Mark Lost." %>
   <% else %>
-    <%= button_to "Mark Won", mark_won_job_proposal_path(@job_proposal),
-          method: :patch,
-          class: "btn btn-outline-success btn-sm",
-          form: { class: "d-inline" } %>
+    <button type="button" class="btn btn-outline-success btn-sm"
+            data-bs-toggle="modal" data-bs-target="#markWonModal">
+      Mark Won
+    </button>
     <button type="button" class="btn btn-outline-danger btn-sm"
             data-bs-toggle="modal" data-bs-target="#markLostModal">
       Mark Lost
@@ -470,6 +470,28 @@
 </div>
 
 <% unless %w[won lost].include?(@job_proposal.pipeline_stage) %>
+  <div class="modal fade" id="markWonModal" tabindex="-1" aria-labelledby="markWonModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <%= form_with url: mark_won_job_proposal_path(@job_proposal), method: :patch, local: true do |f| %>
+          <div class="modal-header">
+            <h5 class="modal-title" id="markWonModalLabel">Mark this job as won</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p class="mb-0">
+              This job will be marked as won. All automated follow-ups will stop and the job will be removed from active campaigns.
+            </p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <%= f.submit "Mark Won", class: "btn btn-success" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
   <div class="modal fade" id="markLostModal" tabindex="-1" aria-labelledby="markLostModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -1265,15 +1265,16 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_nil jp.reload.pipeline_stage
   end
 
-  test "show page renders Mark Won button and a Mark Lost trigger when pipeline_stage is not won/lost" do
+  test "show page renders Mark Won and Mark Lost triggers when pipeline_stage is not won/lost" do
     sign_in @user
     jp = job_proposals(:in_users_org)
     jp.update!(pipeline_stage: nil)
     get job_proposal_url(jp)
     assert_response :success
-    assert_select "form[action=?] button", mark_won_job_proposal_path(jp), text: /Mark Won/
-    # Mark Lost is now a modal trigger button (not a form), and the modal
-    # contains the form posting to mark_lost.
+    # Both Mark Won and Mark Lost are modal triggers; each modal contains
+    # the form that posts the actual transition.
+    assert_select "button[data-bs-target='#markWonModal']", text: /Mark Won/
+    assert_select "#markWonModal form[action=?]", mark_won_job_proposal_path(jp)
     assert_select "button[data-bs-target='#markLostModal']", text: /Mark Lost/
     assert_select "#markLostModal form[action=?]", mark_lost_job_proposal_path(jp)
   end
@@ -1284,7 +1285,8 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     jp.update!(pipeline_stage: "won")
     get job_proposal_url(jp)
     assert_response :success
-    assert_select "form[action=?]", mark_won_job_proposal_path(jp), count: 0
+    assert_select "button[data-bs-target='#markWonModal']", count: 0
+    assert_select "#markWonModal", count: 0
     assert_select "button[data-bs-target='#markLostModal']", count: 0
     assert_select "#markLostModal", count: 0
   end

--- a/test/system/job_proposals_test.rb
+++ b/test/system/job_proposals_test.rb
@@ -1,0 +1,50 @@
+require "application_system_test_case"
+
+class JobProposalsTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+    @proposal = job_proposals(:in_users_org)
+    @proposal.update!(pipeline_stage: :in_campaign, won_at: nil)
+
+    visit new_user_session_path
+    fill_in "Email", with: @user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+  end
+
+  # --- Mark Won confirmation modal (SPEC-09 v1.2.1 §2.2) -------------------
+
+  test "Mark Won opens a confirmation modal with the exact SPEC-09 copy" do
+    visit job_proposal_path(@proposal)
+
+    within "#markWonModal" do
+      assert_text "Mark this job as won"
+      assert_text "This job will be marked as won. All automated follow-ups will stop and the job will be removed from active campaigns."
+      assert_button "Cancel"
+      assert_button "Mark Won"
+    end
+  end
+
+  test "Cancel on the Mark Won modal makes no state change" do
+    visit job_proposal_path(@proposal)
+
+    within "#markWonModal" do
+      click_button "Cancel"
+    end
+
+    @proposal.reload
+    assert_equal "in_campaign", @proposal.pipeline_stage
+    assert_nil @proposal.won_at
+  end
+
+  test "Confirming Mark Won transitions the proposal to won" do
+    visit job_proposal_path(@proposal)
+
+    within "#markWonModal" do
+      click_button "Mark Won"
+    end
+
+    assert_current_path job_proposal_path(@proposal)
+    assert_equal "won", @proposal.reload.pipeline_stage
+  end
+end


### PR DESCRIPTION
The view changes mirror the Mark Lost modal exactly: same guard wrapping both modals, same `form_with ... method: :patch, local: true` shape, same outlined trigger → solid submit pattern (`btn-success` for Won, `btn-danger` for Lost). Modal title, body, and button labels are verbatim from SPEC-09 §2.2.

## Summary of changes

**`app/views/job_proposals/show.html.erb`**
- Replaced the inline `button_to "Mark Won"` form trigger with a plain `<button data-bs-toggle="modal" data-bs-target="#markWonModal">`.
- Added `#markWonModal` alongside `#markLostModal`, inside the same `unless %w[won lost].include?(...)` guard. Modal contains the form posting `PATCH mark_won_job_proposal_path`, the SPEC-09 §2.2 title/body verbatim, and Cancel + Mark Won buttons.

**`test/controllers/job_proposals_controller_test.rb`**
- Updated the two existing render-assertion tests that previously expected `mark_won` to be a bare form to instead expect the modal-trigger pattern (parallel to the existing Mark Lost assertions).

**`test/system/job_proposals_test.rb`** (new)
- Three tests: modal copy renders with exact SPEC-09 strings; Cancel produces no state change; submitting the modal flips `pipeline_stage` to `won`.

## What I couldn't do

I could not run the test suite — Docker can't mount this workspace path (sandbox limitation), and the host Ruby can't install native gem extensions (no build toolchain). Per `CLAUDE.md` you should run the full three-suite test pass (`rails test`, `rails test:system`, `cucumber`) before considering this done; please do so locally. The system test assumes rack_test (matching the existing `application_system_test_case.rb`) — the modal markup is in the DOM regardless of Bootstrap JS, so `within "#markWonModal"` and `click_button` work without a JS driver.

---
Closes #255

🤖 Generated by the F-Agent coding agent.