### PR TITLE
Issue #256: Move Back to Jobs link above the header card (JD-009)

### DIFF
--- a/app/views/job_proposals/not_found.html.erb
+++ b/app/views/job_proposals/not_found.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "Job not found" %>
 
-<p>This job couldn't be found.</p>
 <%= link_to "← Back to Jobs", job_proposals_path, class: "small text-muted" %>
+<p class="mt-2">This job couldn't be found.</p>

--- a/test/controllers/job_proposals_controller_test.rb
+++ b/test/controllers/job_proposals_controller_test.rb
@@ -393,6 +393,8 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "1247 Oak Ridge Drive", response.body
     assert_match "Alice", response.body
+    assert_select "a.small.text-muted[href=?]", job_proposals_path, text: /Back to Jobs/
+    assert_select "a[href=?] ~ div.d-flex h1", job_proposals_path
   end
 
   test "show offers a Resume campaign button when the campaign stopped on a customer reply" do
@@ -422,6 +424,7 @@ class JobProposalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
     assert_match "This job couldn't be found.", response.body
     assert_select "a[href=?]", job_proposals_path, text: /Back to Jobs/
+    assert_select "a[href=?] ~ p", job_proposals_path, text: /This job couldn't be found\./
   end
 
   test "show renders the customer's email in the Customer section as a mailto link" do


### PR DESCRIPTION
Done. Committed as `aa5369d`.

**Summary of changes**
- `app/views/job_proposals/not_found.html.erb` — flipped the order so the back link sits above the "This job couldn't be found." message. The show template already had the link above the header card (from #252), so no edit needed there.
- `test/controllers/job_proposals_controller_test.rb` — added DOM-order assertions to both the `#show` and not-found tests. The show test uses `a ~ div.d-flex h1` to prove the link is a sibling *before* the header card (fails if the link is moved back inside); the not-found test uses `a ~ p` for the same guarantee against the message.

**Test results** — all three suites green:
- minitest: 934 runs, 0 failures
- system: 11 runs, 0 failures
- cucumber: 22 scenarios, all passed

---
Closes #256

🤖 Generated by the F-Agent coding agent.