### PR TITLE
fix(oauth): reject Gmail connections with no refresh token

### DIFF
--- a/app/controllers/email_delegations_controller.rb
+++ b/app/controllers/email_delegations_controller.rb
@@ -1,4 +1,19 @@
 class EmailDelegationsController < ApplicationController
+  # Shown when Google connects an account but returns no refresh token. Without
+  # one, GmailSender#refresh_if_needed has nothing to renew with, so the access
+  # token Google just issued dies within the hour and the connection is dead.
+  # This happens on reconnect when Google still remembers a prior grant: it
+  # returns an access token without a refresh token and shows the streamlined
+  # consent screen. The in-app Disconnect only deletes our local row — it does
+  # not revoke the grant at Google — so reconnecting alone never fixes it. The
+  # user must revoke at Google first to force a clean re-consent.
+  REFRESH_TOKEN_REQUIRED_ALERT = <<~MSG.squish.freeze
+    Google connected your account but didn't return a renewal token, so this
+    connection would stop working within an hour. Remove ServiceMark AI at
+    myaccount.google.com/permissions, then click "Setup G Suite" again to
+    reconnect.
+  MSG
+
   def create
     auth = request.env["omniauth.auth"]
     if auth.blank?
@@ -18,6 +33,15 @@ class EmailDelegationsController < ApplicationController
     )
     delegation.access_token = auth.credentials.token
     delegation.refresh_token = auth.credentials.refresh_token if auth.credentials.refresh_token.present?
+
+    # Don't persist a connection that can't be renewed. A previously-stored
+    # refresh token (kept by the line above when Google returns none on
+    # reconnect) keeps a working delegation alive; only block when there's no
+    # usable refresh token at all.
+    if delegation.refresh_token.blank?
+      redirect_to profile_path, alert: REFRESH_TOKEN_REQUIRED_ALERT and return
+    end
+
     delegation.expires_at = Time.zone.at(auth.credentials.expires_at) if auth.credentials.expires_at
     delegation.scopes = Array(auth.extra&.dig("raw_info", "scope") || auth.credentials.scope).join(" ")
     delegation.save!
@@ -62,6 +86,13 @@ class EmailDelegationsController < ApplicationController
     mailbox.email = auth.info.email
     mailbox.access_token = auth.credentials.token
     mailbox.refresh_token = auth.credentials.refresh_token if auth.credentials.refresh_token.present?
+
+    # Same renewal requirement as a per-user delegation (see create): an
+    # application mailbox with no refresh token dies within the hour.
+    if mailbox.refresh_token.blank?
+      redirect_to admin_application_mailbox_path, alert: REFRESH_TOKEN_REQUIRED_ALERT and return
+    end
+
     mailbox.expires_at = Time.zone.at(auth.credentials.expires_at) if auth.credentials.expires_at
     mailbox.scopes = Array(auth.extra&.dig("raw_info", "scope") || auth.credentials.scope).join(" ")
     mailbox.save!

--- a/test/controllers/email_delegations_controller_test.rb
+++ b/test/controllers/email_delegations_controller_test.rb
@@ -73,14 +73,15 @@ class EmailDelegationsControllerTest < ActionDispatch::IntegrationTest
   # create a connection that silently breaks within the hour.
   test "callback refuses to save a new delegation when Google returns no refresh token" do
     sign_in @user
-    Rails.application.env_config["omniauth.auth"] = auth_without_refresh_token
+    OmniAuth.config.mock_auth[:google_oauth2] = auth_without_refresh_token
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
 
     assert_no_difference -> { @user.email_delegations.count } do
       get "/auth/google_oauth2/callback"
     end
     assert_redirected_to profile_path
     follow_redirect!
-    assert_match(/didn't return a renewal token/i, response.body)
+    assert_match(/return a renewal token/i, response.body)
     assert_match %r{myaccount\.google\.com/permissions}, response.body
   end
 
@@ -95,7 +96,8 @@ class EmailDelegationsControllerTest < ActionDispatch::IntegrationTest
       access_token: "old-token",
       refresh_token: "kept-refresh"
     )
-    Rails.application.env_config["omniauth.auth"] = auth_without_refresh_token
+    OmniAuth.config.mock_auth[:google_oauth2] = auth_without_refresh_token
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
 
     assert_no_difference -> { @user.email_delegations.count } do
       get "/auth/google_oauth2/callback"

--- a/test/controllers/email_delegations_controller_test.rb
+++ b/test/controllers/email_delegations_controller_test.rb
@@ -67,6 +67,45 @@ class EmailDelegationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "refresh-token-xyz", delegation.refresh_token
   end
 
+  # Google omits the refresh token on a reconnect when it still remembers a
+  # prior grant. A delegation saved without one can't be renewed and dies at
+  # access-token expiry, so the callback must refuse to persist it rather than
+  # create a connection that silently breaks within the hour.
+  test "callback refuses to save a new delegation when Google returns no refresh token" do
+    sign_in @user
+    Rails.application.env_config["omniauth.auth"] = auth_without_refresh_token
+
+    assert_no_difference -> { @user.email_delegations.count } do
+      get "/auth/google_oauth2/callback"
+    end
+    assert_redirected_to profile_path
+    follow_redirect!
+    assert_match(/didn't return a renewal token/i, response.body)
+    assert_match %r{myaccount\.google\.com/permissions}, response.body
+  end
+
+  # The legitimate reconnect case: a delegation already has a stored refresh
+  # token and Google returns none. The stored token is preserved and the
+  # connection keeps working — the guard must not block this.
+  test "callback keeps an existing delegation working when reconnect returns no refresh token" do
+    sign_in @user
+    @user.email_delegations.create!(
+      provider: "google_oauth2",
+      email: "owner@example.com",
+      access_token: "old-token",
+      refresh_token: "kept-refresh"
+    )
+    Rails.application.env_config["omniauth.auth"] = auth_without_refresh_token
+
+    assert_no_difference -> { @user.email_delegations.count } do
+      get "/auth/google_oauth2/callback"
+    end
+    assert_redirected_to profile_path
+    delegation = @user.email_delegations.first
+    assert_equal "access-token-abc", delegation.access_token, "access token should refresh"
+    assert_equal "kept-refresh", delegation.refresh_token, "stored refresh token should be preserved"
+  end
+
   test "failure path shows an alert" do
     sign_in @user
     get "/auth/failure", params: { message: "invalid_credentials" }
@@ -114,6 +153,23 @@ class EmailDelegationsControllerTest < ActionDispatch::IntegrationTest
   # trip in tests we drive the request phase first (allowing GET so we
   # bypass omniauth-rails_csrf_protection) and follow the mock redirect to
   # the callback path.
+
+  # A google_oauth2 auth hash with no refresh token, mirroring what Google
+  # returns on a reconnect when it still holds a prior grant.
+  def auth_without_refresh_token
+    OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "1234567890",
+      info: { email: "owner@example.com", name: "Owner" },
+      credentials: {
+        token: "access-token-abc",
+        refresh_token: nil,
+        expires_at: 1.hour.from_now.to_i,
+        scope: "email profile https://www.googleapis.com/auth/gmail.send"
+      },
+      extra: { raw_info: { scope: "email profile https://www.googleapis.com/auth/gmail.send" } }
+    )
+  end
 
   def with_omniauth_get_allowed
     prior = OmniAuth.config.allowed_request_methods.dup


### PR DESCRIPTION
## Bug: Gmail delegations silently die after ~1 hour

**Reported:** SERVPRO North East Dallas (Joe / Jeff Stone), 2026-06-16. A user links Gmail, shows **Linked**, then within the hour flips to *"OAuth expired and can't use it."* Reconnecting from the Profile page doesn't fix it — it keeps expiring in ~1 hour, and Google shows only "approve/continue" with **no permission checkboxes**.

### Root cause
`EmailDelegationsController#create` persists the delegation whether or not Google returned a **refresh token**. `GmailSender#refresh_if_needed` can only renew when a refresh token exists, so a delegation stored without one works until the ~1h access token expires, then is permanently dead.

Google omits the refresh token on **reconnect** when it still remembers a prior grant (the streamlined "no checkboxes" screen). The in-app **Disconnect** only deletes our local row — it does **not** revoke the grant at Google — so reconnecting alone reproduces the dead state every time. OAuth request config is already correct (`access_type=offline`, `prompt=consent`); the gap is that the app accepts a connection it knows can't be renewed.

### Fix
Refuse to persist a delegation/mailbox with no usable refresh token; redirect with an actionable message (revoke at `myaccount.google.com/permissions`, then reconnect). Preserves the legitimate reconnect case: an **already-stored** refresh token is kept when Google returns none, so working connections keep working. Guards both the per-user and application-mailbox paths.

### Tests
- New delegation with no refresh token → rejected, no row created, actionable alert shown.
- Reconnect with a stored refresh token but none returned → still succeeds, access token refreshed, stored refresh token preserved.

### Verification status
- ✅ `ruby -c` syntax-clean on both changed files.
- ⚠️ Full Minitest suite **not run locally** — needs the app's Ruby toolchain + Postgres test DB, which isn't set up on the authoring machine. Tests follow the existing `OmniAuth.config.mock_auth` / `assert_no_difference` patterns in this file exactly. **Please let CI validate before merge.**

### Operational workaround (no deploy needed, for affected users now)
1. `myaccount.google.com/permissions` (signed in as the affected account)
2. **ServiceMark AI** → **Remove access**
3. ServiceMark AI → Profile → **Setup G Suite** → approve

### Optional follow-ups (your call, not in this PR)
- One-click "Remove access at Google" link in the Profile UI.
- Background sweep that detects `expired? && refresh_token.blank?` and emails the user to reconnect.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — opened for **@mfrizzell to review**; not auto-merged (your repo, your call).
